### PR TITLE
feat: add workflow graph JSON templates to examples/

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,43 @@
+# Workflow Graph Templates
+
+Ready-made workflow graph JSON templates you can use to quickly try dify-mcp with a working workflow.
+
+## Templates
+
+| Template | Description | Nodes |
+|----------|-------------|-------|
+| [`echo-input.json`](./echo-input.json) | Echo — passes the user input straight through | start → end |
+| [`simple-llm.json`](./simple-llm.json) | Simple LLM — sends the input to an LLM and returns the response | start → LLM → answer |
+| [`rag-pipeline.json`](./rag-pipeline.json) | RAG pipeline — retrieves context from a knowledge base, then asks the LLM to answer using that context | start → knowledge retrieval → LLM → answer |
+
+## Usage
+
+### Validate a template offline
+
+```bash
+# The graph is validated automatically when used with --dry-run
+difywf wf draft sync --graph examples/simple-llm.json --dry-run
+```
+
+### Import into a Dify app
+
+```bash
+# Sync the graph to a draft workflow (replace APP_ID and credentials)
+difywf wf draft sync \
+  --graph examples/simple-llm.json \
+  --credentials '{"app_id":"YOUR_APP_ID","api_key":"YOUR_API_KEY"}'
+```
+
+### Use with MCP
+
+Pass the graph JSON to any MCP-compatible tool that accepts a `graph` parameter.
+
+## Adapting templates
+
+Each template uses placeholder values you'll need to replace:
+
+- **`YOUR_DATASET_ID`** in `rag-pipeline.json` — replace with your actual Dify dataset ID
+- **Model provider/name** — change `openai` / `gpt-4o-mini` to match your configured provider
+- **Variable names** — adjust `query`, `answer`, etc. to fit your use case
+
+The templates follow the [Dify workflow graph schema](https://docs.dify.ai/) with `nodes` (typed by `data.type`) and `edges` (connecting `source` → `target`).

--- a/examples/echo-input.json
+++ b/examples/echo-input.json
@@ -1,0 +1,27 @@
+{
+  "nodes": [
+    {
+      "id": "start1",
+      "data": {
+        "type": "start",
+        "title": "Start",
+        "variables": [
+          { "variable": "query", "type": "text-input", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "end1",
+      "data": {
+        "type": "end",
+        "title": "End",
+        "outputs": [
+          { "variable": "result", "value_selector": ["start1", "query"] }
+        ]
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start1", "target": "end1", "sourceHandle": "source", "targetHandle": "target" }
+  ]
+}

--- a/examples/rag-pipeline.json
+++ b/examples/rag-pipeline.json
@@ -1,0 +1,54 @@
+{
+  "nodes": [
+    {
+      "id": "start1",
+      "data": {
+        "type": "start",
+        "title": "Start",
+        "variables": [
+          { "variable": "query", "type": "text-input", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "kr1",
+      "data": {
+        "type": "knowledge-retrieval",
+        "title": "Knowledge Retrieval",
+        "query_variable_selector": ["start1", "query"],
+        "dataset_ids": ["YOUR_DATASET_ID"]
+      }
+    },
+    {
+      "id": "llm1",
+      "data": {
+        "type": "llm",
+        "title": "LLM",
+        "model": {
+          "provider": "openai",
+          "name": "gpt-4o-mini",
+          "mode": "chat",
+          "completion_params": {}
+        },
+        "prompt_template": [
+          { "role": "user", "text": "Based on the following context, answer the question.\n\nContext: {{#kr1.result#}}\n\nQuestion: {{#start1.query#}}" }
+        ]
+      }
+    },
+    {
+      "id": "end1",
+      "data": {
+        "type": "end",
+        "title": "End",
+        "outputs": [
+          { "variable": "answer", "value_selector": ["llm1", "text"] }
+        ]
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start1", "target": "kr1", "sourceHandle": "source", "targetHandle": "target" },
+    { "id": "e2", "source": "kr1", "target": "llm1", "sourceHandle": "source", "targetHandle": "target" },
+    { "id": "e3", "source": "llm1", "target": "end1", "sourceHandle": "source", "targetHandle": "target" }
+  ]
+}

--- a/examples/simple-llm.json
+++ b/examples/simple-llm.json
@@ -1,0 +1,44 @@
+{
+  "nodes": [
+    {
+      "id": "start1",
+      "data": {
+        "type": "start",
+        "title": "Start",
+        "variables": [
+          { "variable": "query", "type": "text-input", "required": true }
+        ]
+      }
+    },
+    {
+      "id": "llm1",
+      "data": {
+        "type": "llm",
+        "title": "LLM",
+        "model": {
+          "provider": "openai",
+          "name": "gpt-4o-mini",
+          "mode": "chat",
+          "completion_params": {}
+        },
+        "prompt_template": [
+          { "role": "user", "text": "Answer this question: {{#start1.query#}}" }
+        ]
+      }
+    },
+    {
+      "id": "end1",
+      "data": {
+        "type": "end",
+        "title": "End",
+        "outputs": [
+          { "variable": "answer", "value_selector": ["llm1", "text"] }
+        ]
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "start1", "target": "llm1", "sourceHandle": "source", "targetHandle": "target" },
+    { "id": "e2", "source": "llm1", "target": "end1", "sourceHandle": "source", "targetHandle": "target" }
+  ]
+}


### PR DESCRIPTION
## Problem

The `examples/` directory doesn't exist yet, so new users have no ready-made workflow graphs to try dify-mcp with. Issue #2 requests templates so users can quickly test the tool without building a graph from scratch.

## Fix

Added three workflow graph JSON templates covering common patterns:

- **`echo-input.json`** — start → end (passthrough, simplest possible workflow)
- **`simple-llm.json`** — start → LLM → answer (basic chatbot pattern)
- **`rag-pipeline.json`** — start → knowledge retrieval → LLM → answer (RAG pattern)

Each template:
- Follows the Dify workflow graph schema (`nodes` + `edges`)
- Validates cleanly against `validateGraph()` with zero errors
- Uses placeholder values (`YOUR_DATASET_ID`, model provider) that users replace for their setup

Includes `examples/README.md` with a usage table, CLI examples for validation and import, and adaptation guidance.

## Test Plan

- [x] All 42 existing tests pass (`npm test`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] All three templates validate cleanly against `validateGraph()`
- [ ] `npm run smoke:mcp` (requires MCP runtime — manual verification)

Closes #2
