### PR TITLE
feat(mcp): Streamable HTTP transport + expand node-type validator schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ create workflows, wire up nodes, test them, iterate, and publish — without a b
 
 **dify-mcp** is the bridge. It exposes the **entire Dify console API** as a unified
 tool registry with **two surfaces**: a CLI any shell-capable agent can drive, and an
-MCP server (stdio) any MCP-compatible host can attach. Same 138 tools, same JSON
+MCP server (stdio or Streamable HTTP) any MCP-compatible host can attach. Same 138 tools, same JSON
 contract, same safety guarantees.
 
 ```
@@ -98,7 +98,7 @@ Every tool category has been tested against **cloud.dify.ai** with real credenti
 - ✅ Full authoring loop: create app → sync draft → run draft → publish → list versions
 - ✅ All 16 namespaces exercised: apps, workflows, providers, plugins, triggers,
   snippets, RAG, agents, stats, comments, annotations, audio, files, runs, workspace
-- ✅ MCP transport: `tools/call` over stdio with live cookie auth
+- ✅ MCP transport: `tools/call` over stdio and Streamable HTTP with live cookie auth
 - ✅ 42 unit tests · typecheck clean · MCP smoke (138 tools)
 
 ## Quickstart
@@ -227,6 +227,22 @@ Aider doesn't support MCP, but it can run shell commands. Just use the CLI direc
 ```
 </details>
 
+<details>
+<summary><b>Remote host? Streamable HTTP instead of stdio</b></summary>
+
+For remote or containerized hosts that can't spawn a local process, run the MCP
+server over the stateless Streamable HTTP transport:
+
+```bash
+difywf mcp serve --http --port 8080
+# or via env: DIFYWF_MCP_TRANSPORT=http DIFYWF_MCP_PORT=8080 difywf mcp serve
+```
+
+Point any Streamable-HTTP-capable client at `http://<host>:8080/mcp`. Each POST is
+a self-contained JSON-RPC message (initialize / tools/list / tools/call); no
+session is required. GET and DELETE are rejected with 405.
+</details>
+
 > No `difywf` on PATH? Use the absolute path: `node /path/to/dify-mcp/bin/difywf.js mcp serve`.
 
 ## Tools
@@ -275,6 +291,7 @@ before retrying.
 npm run typecheck   # tsc --noEmit
 npm test            # 42 unit tests
 npm run smoke:mcp   # MCP stdio smoke (138 tools, JSON-RPC handshake)
+npm run smoke:mcp:http   # MCP Streamable HTTP smoke (stateless POST /mcp)
 ```
 
 No build step. Source runs directly via Node's type stripping.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "node --test test/*.test.ts",
-    "smoke:mcp": "node scripts/mcp-smoke.mjs"
+    "smoke:mcp": "node scripts/mcp-smoke.mjs",
+    "smoke:mcp:http": "node scripts/mcp-smoke-http.mjs"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/scripts/mcp-smoke-http.mjs
+++ b/scripts/mcp-smoke-http.mjs
@@ -1,0 +1,84 @@
+// MCP Streamable HTTP smoke test: start the server in --http mode, then run
+// initialize -> tools/list -> tools/call against POST /mcp (stateless).
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const PORT = String(9123 + (process.pid % 97));
+const server = spawn(process.execPath, [path.join(root, "src", "mcp.ts"), "--http", "--port", PORT], {
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+let stderrBuf = "";
+const ready = new Promise((resolve, reject) => {
+  const to = setTimeout(() => reject(new Error("server did not announce listening")), 15000);
+  server.stderr.on("data", (c) => {
+    stderrBuf += c.toString();
+    if (stderrBuf.includes("listening on")) { clearTimeout(to); resolve(); }
+  });
+});
+
+const fail = (msg) => { console.error(`SMOKE FAIL: ${msg}`); server.kill("SIGKILL"); process.exit(1); };
+
+const post = (body) =>
+  fetch(`http://127.0.0.1:${PORT}/mcp`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+    body: JSON.stringify(body),
+  });
+
+// A Streamable HTTP response may be a single JSON object (application/json) or
+// an SSE stream (text/event-stream) whose data: line holds the JSON-RPC msg.
+const readResult = async (res) => {
+  const ct = res.headers.get("content-type") ?? "";
+  const text = await res.text();
+  if (ct.includes("text/event-stream")) {
+    const line = text.split("\n").find((l) => l.startsWith("data:"));
+    if (!line) throw new Error(`SSE without data: ${text}`);
+    return JSON.parse(line.slice(5).trim());
+  }
+  if (text === "") return undefined;
+  return JSON.parse(text);
+};
+
+try {
+  await ready;
+  console.log("http server ready");
+
+  const init = await post({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "difywf-smoke-http", version: "0.1.0" } } });
+  const initRes = await readResult(init);
+  if (!initRes?.result?.serverInfo?.name) fail(`initialize bad: ${JSON.stringify(initRes)}`);
+  console.log("initialize OK");
+
+  const list = await post({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+  const listRes = await readResult(list);
+  const names = (listRes?.result?.tools ?? []).map((t) => t.name);
+  if (names.length < 15) fail(`expected >=15 tools, got ${names.length}`);
+  for (const req of ["agent_guide", "workflow_validate", "workflow_sync_draft", "app_create"]) {
+    if (!names.includes(req)) fail(`missing tool ${req}`);
+  }
+  console.log(`tools/list OK (${names.length} tools)`);
+
+  const validate = await post({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "workflow_validate", arguments: { graph: { nodes: [{ id: "s", data: { type: "start", variables: [] } }], edges: [] } } } });
+  const validateRes = await readResult(validate);
+  const validatePayload = JSON.parse(validateRes.result.content[0].text);
+  if (!validatePayload.ok || validatePayload.data.valid !== true) fail(`workflow_validate bad: ${JSON.stringify(validatePayload)}`);
+  console.log("tools/call workflow_validate OK");
+
+  const denied = await post({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "app_delete", arguments: { app_id: "x" } } });
+  const deniedRes = await readResult(denied);
+  const deniedPayload = JSON.parse(deniedRes.result.content[0].text);
+  if (deniedPayload.ok || deniedPayload.error?.code !== "CONFIRM_REQUIRED") fail(`confirm gate not enforced: ${JSON.stringify(deniedPayload)}`);
+  console.log("confirm gate OK");
+
+  const get = await fetch(`http://127.0.0.1:${PORT}/mcp`, { method: "GET" });
+  if (get.status !== 405) fail(`GET should be 405, got ${get.status}`);
+  console.log("GET 405 OK");
+} catch (e) {
+  fail(e instanceof Error ? e.message : String(e));
+}
+
+server.kill("SIGTERM");
+console.log("SMOKE PASS");
+process.exit(0);

--- a/src/graph/validate.ts
+++ b/src/graph/validate.ts
@@ -43,6 +43,11 @@ const REQUIRED: Record<string, string[]> = {
   "question-classifier": ["query_variable_selector", "classes"],
   "if-else": ["conditions", "logical_operator"],
   "variable-aggregator": ["variables"],
+  tool: ["provider_id", "provider_type", "tool_name"],
+  "parameter-extractor": ["query", "model", "parameters"],
+  assigner: ["items"],
+  iteration: ["iterator_selector", "start_node_id"],
+  loop: ["start_node_id"],
 };
 
 const KNOWN_TYPES = new Set([

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,9 +1,11 @@
-// MCP surface: stdio server exposing the same registry as tools (dots become
-// underscores) plus the difywf://guide resource. Stable spec subset only:
-// tools + resources, no elicitation/sampling/roots.
+// MCP surface: stdio (default) or Streamable HTTP, exposing the same tool
+// registry (dots become underscores) plus the difywf://guide resource.
+// Stable spec subset only: tools + resources, no elicitation/sampling/roots.
 
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import {
   CallToolRequestSchema,
   ListResourcesRequestSchema,
@@ -16,38 +18,118 @@ import { guideText } from "./tools/guide.ts";
 
 const mcpName = (n: string): string => n.replaceAll(".", "_");
 
-const server = new Server(
-  { name: "difywf", version: "0.1.0" },
-  { capabilities: { tools: {}, resources: {} } },
-);
+// Fresh server per connection: the SDK throws if connect() is called twice on
+// one instance, so stateless HTTP builds one per request (cheap: four request
+// handlers over a shared tool registry, not per-tool registration). Stdio uses
+// a single instance for the process lifetime.
+function createMcpServer(): Server {
+  const server = new Server(
+    { name: "difywf", version: "0.1.0" },
+    { capabilities: { tools: {}, resources: {} } },
+  );
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: tools.map((t) => ({
-    name: mcpName(t.name),
-    description: t.summary,
-    inputSchema: t.schema as { type: "object"; properties?: Record<string, unknown>; required?: string[] },
-  })),
-}));
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: tools.map((t) => ({
+      name: mcpName(t.name),
+      description: t.summary,
+      inputSchema: t.schema as { type: "object"; properties?: Record<string, unknown>; required?: string[] },
+    })),
+  }));
 
-server.setRequestHandler(CallToolRequestSchema, async (req) => {
-  const tool = tools.find((t) => mcpName(t.name) === req.params.name);
-  const result = tool
-    ? await runTool(tool, (req.params.arguments ?? {}) as Record<string, unknown>, { _surface: "mcp" })
-    : err("USAGE_ERROR", `unknown tool '${req.params.name}'`);
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-    isError: !result.ok,
-  };
-});
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const tool = tools.find((t) => mcpName(t.name) === req.params.name);
+    const result = tool
+      ? await runTool(tool, (req.params.arguments ?? {}) as Record<string, unknown>, { _surface: "mcp" })
+      : err("USAGE_ERROR", `unknown tool '${req.params.name}'`);
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      isError: !result.ok,
+    };
+  });
 
-server.setRequestHandler(ListResourcesRequestSchema, async () => ({
-  resources: [
-    { uri: "difywf://guide", name: "difywf agent guide", mimeType: "text/markdown", description: "Authoring playbook: golden path, node types, error codes, safety rules" },
-  ],
-}));
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    resources: [
+      { uri: "difywf://guide", name: "difywf agent guide", mimeType: "text/markdown", description: "Authoring playbook: golden path, node types, error codes, safety rules" },
+    ],
+  }));
 
-server.setRequestHandler(ReadResourceRequestSchema, async (req) => ({
-  contents: [{ uri: req.params.uri, mimeType: "text/markdown", text: guideText("all") }],
-}));
+  server.setRequestHandler(ReadResourceRequestSchema, async (req) => ({
+    contents: [{ uri: req.params.uri, mimeType: "text/markdown", text: guideText("all") }],
+  }));
 
-await server.connect(new StdioServerTransport());
+  return server;
+}
+
+function argValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : undefined;
+}
+
+const transportMode = (
+  process.env.DIFYWF_MCP_TRANSPORT ?? (process.argv.includes("--http") ? "http" : "stdio")
+).toLowerCase();
+
+if (transportMode === "http") {
+  startHttpServer(Number(argValue("--port") ?? process.env.DIFYWF_MCP_PORT ?? 3000));
+} else {
+  await createMcpServer().connect(new StdioServerTransport());
+}
+
+// --- Streamable HTTP transport (stateless, one server per request) ---
+function startHttpServer(port: number): void {
+  const httpServer = createServer((req, res) => {
+    handleHttpRequest(req, res).catch((e) => {
+      if (!res.headersSent) {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ jsonrpc: "2.0", error: { code: -32603, message: String(e) }, id: null }));
+      }
+    });
+  });
+  httpServer.listen(port, () => {
+    process.stderr.write(`difywf MCP (Streamable HTTP) listening on http://0.0.0.0:${port}/mcp\n`);
+  });
+  const shutdown = (): void => { httpServer.close(); process.exit(0); };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+async function handleHttpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (req.method !== "POST") {
+    return writeJsonRpcError(res, 405, -32000, "Method not allowed. POST a JSON-RPC message to /mcp.");
+  }
+  let parsedBody: unknown;
+  try {
+    parsedBody = await readBody(req);
+  } catch {
+    return writeJsonRpcError(res, 400, -32700, "Parse error: request body is not valid JSON.");
+  }
+  // Stateless: no session id. Each POST is a self-contained JSON-RPC message,
+  // so initialize / tools/list / tools/call all work without prior state.
+  const mcp = createMcpServer();
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  try {
+    await mcp.connect(transport);
+    await transport.handleRequest(req, res, parsedBody);
+  } catch (e) {
+    if (!res.headersSent) {
+      writeJsonRpcError(res, 500, -32603, `Internal error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  } finally {
+    res.on("close", () => {
+      transport.close().catch(() => {});
+      mcp.close().catch(() => {});
+    });
+  }
+}
+
+async function readBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  return raw ? JSON.parse(raw) : undefined;
+}
+
+function writeJsonRpcError(res: ServerResponse, status: number, code: number, message: string): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify({ jsonrpc: "2.0", error: { code, message }, id: null }));
+}

--- a/src/tools/guide.ts
+++ b/src/tools/guide.ts
@@ -50,7 +50,10 @@ Minimal required fields per type (validator enforces these):
 - code: code_language, code, outputs   http-request: method, url
 - knowledge-retrieval: query_variable_selector, dataset_ids
 - if-else: conditions, logical_operator   variable-aggregator: variables
-Unknown/plugin types are warnings, not errors — but still validate structure.`,
+- tool: provider_id, provider_type, tool_name
+- parameter-extractor: query, model, parameters   assigner: items
+- iteration: iterator_selector, start_node_id   loop: start_node_id
+Unknown/plugin types are warnings, not errors - but still validate structure.`,
 
   errors: `# Error codes (stable; check "retryable" before retrying)
 USAGE_ERROR(2) bad args — fix the call.

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -1,0 +1,85 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { validateGraph, type Graph, type Issue } from "../src/graph/validate.ts";
+
+const codes = (issues: Issue[]): string[] => issues.filter((i) => i.level === "error").map((i) => i.code);
+const missing = (issues: Issue[]): string[] =>
+  issues.filter((i) => i.level === "error" && i.code === "MISSING_REQUIRED_FIELD").map((i) => i.message);
+
+// Wrap a node under test in start -> uut -> end so it is reachable and any
+// upstream selector refs resolve.
+function wrap(nodeData: Record<string, unknown>): Graph {
+  return {
+    nodes: [
+      { id: "start", data: { type: "start", variables: [{ variable: "query", type: "text-input", required: true }] } },
+      { id: "uut", data: nodeData },
+      { id: "end", data: { type: "end", outputs: [] } },
+    ],
+    edges: [
+      { id: "e1", source: "start", target: "uut" },
+      { id: "e2", source: "uut", target: "end" },
+    ],
+  };
+}
+
+test("tool node: complete -> no errors", () => {
+  const issues = validateGraph(wrap({
+    type: "tool", provider_id: "google", provider_type: "builtin", tool_name: "search", tool_parameters: {},
+  }));
+  assert.deepEqual(codes(issues), []);
+});
+
+test("tool node: missing provider_id/tool_name -> MISSING_REQUIRED_FIELD", () => {
+  const errs = missing(validateGraph(wrap({ type: "tool", provider_type: "builtin" })));
+  assert.ok(errs.some((m) => m.includes("provider_id")), errs.join("; "));
+  assert.ok(errs.some((m) => m.includes("tool_name")), errs.join("; "));
+});
+
+test("parameter-extractor: complete -> no errors", () => {
+  const issues = validateGraph(wrap({
+    type: "parameter-extractor",
+    query: ["start", "query"],
+    model: { provider: "openai", name: "gpt-4o-mini", mode: "chat" },
+    parameters: [{ name: "city", type: "string", description: "x" }],
+  }));
+  assert.deepEqual(codes(issues), []);
+});
+
+test("parameter-extractor: missing model/parameters -> MISSING_REQUIRED_FIELD", () => {
+  const errs = missing(validateGraph(wrap({ type: "parameter-extractor", query: ["start", "query"] })));
+  assert.ok(errs.some((m) => m.includes("model")), errs.join("; "));
+  assert.ok(errs.some((m) => m.includes("parameters")), errs.join("; "));
+});
+
+test("assigner: with items -> no errors", () => {
+  const issues = validateGraph(wrap({
+    type: "assigner",
+    items: [{ variable_selector: ["start", "query"], operation: "set", value: "x" }],
+  }));
+  assert.deepEqual(codes(issues), []);
+});
+
+test("assigner: missing items -> MISSING_REQUIRED_FIELD", () => {
+  assert.ok(missing(validateGraph(wrap({ type: "assigner" }))).some((m) => m.includes("items")));
+});
+
+test("iteration: complete -> no errors", () => {
+  const issues = validateGraph(wrap({
+    type: "iteration", iterator_selector: ["start", "query"], start_node_id: "iter_start",
+  }));
+  assert.deepEqual(codes(issues), []);
+});
+
+test("iteration: missing iterator_selector/start_node_id -> MISSING_REQUIRED_FIELD", () => {
+  const errs = missing(validateGraph(wrap({ type: "iteration" })));
+  assert.ok(errs.some((m) => m.includes("iterator_selector")), errs.join("; "));
+  assert.ok(errs.some((m) => m.includes("start_node_id")), errs.join("; "));
+});
+
+test("loop: complete -> no errors", () => {
+  assert.deepEqual(codes(validateGraph(wrap({ type: "loop", start_node_id: "loop_start" }))), []);
+});
+
+test("loop: missing start_node_id -> MISSING_REQUIRED_FIELD", () => {
+  assert.ok(missing(validateGraph(wrap({ type: "loop" }))).some((m) => m.includes("start_node_id")));
+});


### PR DESCRIPTION
## What

Advances two short-term roadmap items from #1:

- **Streamable HTTP MCP transport** — `difywf mcp serve --http --port 8080` (or `DIFYWF_MCP_TRANSPORT=http`). Stateless Streamable HTTP over `node:http`: each POST to `/mcp` is a self-contained JSON-RPC message (initialize / tools/list / tools/call), no session required. GET/DELETE → 405. Lets remote/containerized hosts attach without spawning a local stdio process.
- **More node-type validator schemas** — adds required-field checks for `tool` (`provider_id`, `provider_type`, `tool_name`), `parameter-extractor` (`query`, `model`, `parameters`), `assigner` (`items`), `iteration` (`iterator_selector`, `start_node_id`), `loop` (`start_node_id`), grounded in Dify's own fixtures and frontend node `default.ts`. The guide's node-type table is updated to match.

## How

- `src/mcp.ts`: refactored to a `createMcpServer()` factory (the SDK throws if `connect()` is called twice on one instance, so stateless HTTP builds a fresh server per request — cheap: 4 request handlers over a shared tool registry). Stdio path unchanged.
- `src/graph/validate.ts`: 5 new entries in the `REQUIRED` table; conservative to avoid false positives (only fields that are unambiguously always required).
- `test/schemas.test.ts` (new): 10 tests — each new type with complete fields produces no errors (no false positive), and each missing a required field yields `MISSING_REQUIRED_FIELD`.
- `scripts/mcp-smoke-http.mjs` (new) + `npm run smoke:mcp:http`: exercises the HTTP server end to end (initialize → tools/list → tools/call → confirm gate → GET 405).
- `README.md`: documents the HTTP transport option.

## Verification

- `npm run typecheck` ✅
- `npm test` ✅ — 53 tests pass (was 43; +10 schema tests)
- `npm run smoke:mcp` ✅ — stdio, 138 tools (no regression)
- `npm run smoke:mcp:http` ✅ — HTTP, 138 tools, full request/response cycle

Closes nothing on its own; checklist updates for #1 to follow.