### PR TITLE
fix(validate): custom-note nodes no longer trigger false errors

### DIFF
--- a/src/graph/validate.ts
+++ b/src/graph/validate.ts
@@ -73,7 +73,15 @@ const REF_SKIP = new Set(["sys", "env", "conversation"]);
 const VAR_REF = /\{\{#([A-Za-z0-9_-]+)\.([A-Za-z0-9_.\[\]-]+)#\}\}/g;
 
 const nodeType = (n: GraphNode): string | undefined =>
-  (n.data?.type as string | undefined) ?? n.type;
+  // Note: use `||` not `??` — decorative nodes (custom-note) carry an empty
+  // string data.type, so fall through to the node-level `type` (e.g. "custom-note").
+  ((n.data?.type as string | undefined) || undefined) ?? n.type;
+
+// Canvas-only decorative nodes: not executable, intentionally unconnected.
+// Excluded from reachability checks. `custom-note` is Dify's sticky-note
+// annotation (node.type === "custom-note", data.type === ""). Extend this set
+// if other non-executable canvas helpers surface.
+const DECORATIVE_TYPES = new Set(["custom-note"]);
 
 export function validateGraph(
   graph: Graph,
@@ -140,6 +148,8 @@ export function validateGraph(
     for (const next of adj.get(id) ?? []) queue.push(next);
   }
   for (const n of nodes) {
+    const t = nodeType(n);
+    if (t && DECORATIVE_TYPES.has(t)) continue; // canvas notes are intentionally unconnected
     if (!reachable.has(n.id) && rootIds.length > 0) {
       issues.push({ level: "error", code: "UNREACHABLE_NODE", message: `node '${n.id}' is not reachable from start`, nodeId: n.id });
     }

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -69,6 +69,24 @@ test("sys and env references are not treated as node refs", () => {
   assert.deepEqual(codes(validateGraph(graph)), []);
 });
 
+test("custom-note annotation nodes do not trigger false errors", () => {
+  // Dify sticky notes: node.type === "custom-note" but data.type === "".
+  // They are intentionally unconnected and must not raise MISSING_NODE_TYPE
+  // or UNREACHABLE_NODE.
+  const graph: Graph = {
+    nodes: [
+      { id: "s", data: { type: "start", variables: [] } },
+      { id: "a", data: { type: "answer", answer: "hi" } },
+      { id: "note1", type: "custom-note", data: { type: "", text: "a sticky note" } },
+    ],
+    edges: [{ source: "s", target: "a" }],
+  };
+  const got = new Set(codes(validateGraph(graph)));
+  assert.ok(!got.has("MISSING_NODE_TYPE"), "custom-note must not raise MISSING_NODE_TYPE");
+  assert.ok(!got.has("UNREACHABLE_NODE"), "custom-note is intentionally unconnected");
+  assert.deepEqual(codes(validateGraph(graph)), []);
+});
+
 test("all example templates in examples/ produce no error-level issues", () => {
   const examplesDir = path.join(dir, "..", "examples");
   const files = ["minimal-workflow.json", "llm-workflow.json", "rag-workflow.json"];


### PR DESCRIPTION
Dify canvas sticky notes are `custom-note` nodes: `node.type === "custom-note"` but `node.data.type === ""` (empty string). The offline validator uses `n.data?.type ?? n.type`, and because `""` is not nullish, the `??` never falls through to the node-level type.

## Impact

Every note produced two false error-level issues:

- `MISSING_NODE_TYPE` — the empty-string `data.type` is read as "present but blank"
- `UNREACHABLE_NODE` — notes are intentionally unconnected to the graph

Any real workflow containing annotation notes (the default Dify workflow template ships with them) fails `validateGraph` and therefore cannot be synced via `workflow.sync_draft` (aborts with exit 5), even though the graph is perfectly valid and runs fine in the Dify UI.

Reproduced live against a self-hosted Dify deployment: pulling an existing "AI summary" workflow that had three `custom-note` cards on the canvas yielded 6 false errors and blocked every draft sync.

## Fix

- `nodeType()`: coerce an empty-string `data.type` to `undefined` so it falls through to the node-level `type` (e.g. `custom-note`).
- Add `DECORATIVE_TYPES` (currently `custom-note`) and skip these nodes in the reachability check, since canvas notes are intentionally unconnected.

## Test

Adds a regression test (`custom-note annotation nodes do not trigger false errors`) asserting neither `MISSING_NODE_TYPE` nor `UNREACHABLE_NODE` is raised. Verified RED before the fix / GREEN after. Full suite: 54/54 pass, `tsc --noEmit` clean.