### PR TITLE
fix(validate): support iteration/loop sub-graph nodes

### DIFF
--- a/src/graph/validate.ts
+++ b/src/graph/validate.ts
@@ -53,7 +53,9 @@ const REQUIRED: Record<string, string[]> = {
 const KNOWN_TYPES = new Set([
   ...Object.keys(REQUIRED),
   "iteration",
+  "iteration-start",
   "loop",
+  "loop-start",
   "tool",
   "parameter-extractor",
   "assigner",
@@ -147,6 +149,22 @@ export function validateGraph(
     reachable.add(id);
     for (const next of adj.get(id) ?? []) queue.push(next);
   }
+  // Iteration/loop sub-graph nodes (parentId set, plus the container's
+  // <id>start node) live inside their container and are not wired to `start`
+  // by normal edges — they run when the reachable container executes. Mark a
+  // node reachable once its parent container is reachable; iterate to a
+  // fixpoint so nested containers propagate.
+  const parentOf = (n: GraphNode): string | undefined =>
+    (n.parentId as string | undefined) ?? (n.data?.iteration_id as string | undefined) ?? (n.data?.loop_id as string | undefined);
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const n of nodes) {
+      if (reachable.has(n.id)) continue;
+      const p = parentOf(n);
+      if (p && reachable.has(p)) { reachable.add(n.id); grew = true; }
+    }
+  }
   for (const n of nodes) {
     const t = nodeType(n);
     if (t && DECORATIVE_TYPES.has(t)) continue; // canvas notes are intentionally unconnected
@@ -184,9 +202,25 @@ export function validateGraph(
         issues.push({ level: "error", code: "BAD_VAR_REF", message: `node '${n.id}' references itself`, nodeId: n.id });
         continue;
       }
-      // ponytail: ignores loop/iteration scoped-variable exceptions; a scoped
-      // reference inside a loop body may false-positive here. Refine when hit.
-      if (!ancestors.get(n.id)?.has(ref)) {
+      // Iteration/loop scoped-variable exceptions (container containment is not
+      // an edge-ancestry relation, so these are legitimate despite failing the
+      // upstream check):
+      //   a) container -> its own inner node: an iteration's output_selector
+      //      names an inner node whose result is collected each pass.
+      //   b) inner node -> its container: inner nodes read the container's
+      //      scoped vars (item/index) via {{#<container>.item#}}.
+      //   c) sibling -> sibling inside the same container: sub-graph ancestry
+      //      is tracked separately; a same-parent ref is in-scope.
+      const refNode = byId.get(ref);
+      const parentIdOf = (x?: GraphNode): string | undefined =>
+        x ? ((x.parentId as string | undefined) ?? (x.data?.iteration_id as string | undefined) ?? (x.data?.loop_id as string | undefined)) : undefined;
+      const nParent = parentIdOf(n);
+      const refParent = parentIdOf(refNode);
+      const scoped =
+        refParent === n.id ||            // (a) n is the container of ref
+        nParent === ref ||               // (b) ref is the container of n
+        (nParent !== undefined && nParent === refParent); // (c) same container
+      if (!scoped && !ancestors.get(n.id)?.has(ref)) {
         issues.push({ level: "error", code: "FORWARD_VAR_REF", message: `node '${n.id}' references '${ref}', which is not upstream of it`, nodeId: n.id });
       }
     }

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -80,6 +80,39 @@ test("loop: complete -> no errors", () => {
   assert.deepEqual(codes(validateGraph(wrap({ type: "loop", start_node_id: "loop_start" }))), []);
 });
 
+test("iteration sub-graph: container + iteration-start + inner node -> no false errors", () => {
+  // Real Dify iteration structure: the container's output_selector names an
+  // inner node, the inner node reads the container's scoped `item`, and the
+  // inner/start nodes are reachable only via parentId containment (not edges
+  // from start). None of these should raise UNREACHABLE_NODE, FORWARD_VAR_REF,
+  // or UNKNOWN_NODE_TYPE.
+  const graph: Graph = {
+    nodes: [
+      { id: "start", data: { type: "start", variables: [{ variable: "query", type: "text-input", required: true }] } },
+      { id: "src", data: { type: "code", code_language: "python3", code: "x", outputs: { arr: { type: "array[object]" } } } },
+      { id: "iter", data: {
+        type: "iteration",
+        iterator_selector: ["src", "arr"],
+        output_selector: ["inner", "text"],
+        start_node_id: "iterstart",
+      } },
+      { id: "iterstart", parentId: "iter", data: { type: "iteration-start", isInIteration: true } },
+      { id: "inner", parentId: "iter", data: {
+        type: "llm", isInIteration: true, iteration_id: "iter",
+        model: {}, prompt_template: [{ role: "user", text: "{{#iter.item#}}" }],
+      } },
+      { id: "end", data: { type: "end", outputs: [] } },
+    ],
+    edges: [
+      { id: "e1", source: "start", target: "src" },
+      { id: "e2", source: "src", target: "iter" },
+      { id: "e3", source: "iter", target: "end" },
+      { id: "e4", source: "iterstart", target: "inner" },
+    ],
+  };
+  assert.deepEqual(codes(validateGraph(graph)), []);
+});
+
 test("loop: missing start_node_id -> MISSING_REQUIRED_FIELD", () => {
   assert.ok(missing(validateGraph(wrap({ type: "loop" }))).some((m) => m.includes("start_node_id")));
 });


### PR DESCRIPTION
## Problem

The offline graph validator flags legitimate iteration/loop workflows with false errors, blocking `sync_draft` (exit 5). Iteration/loop containers hold a **sub-graph** whose nodes are reachable via `parentId` containment (plus the `<id>start` node), not via edges from `start`. This produced:

- `UNREACHABLE_NODE` on `iteration-start` and inner nodes
- `FORWARD_VAR_REF` on the container's `output_selector` (which names an inner node) and on inner nodes reading the container's scoped `item`/`index` var
- `UNKNOWN_NODE_TYPE` warning on `iteration-start`

The existing code even carried a TODO for this: *'ponytail: ignores loop/iteration scoped-variable exceptions; a scoped reference inside a loop body may false-positive here. Refine when hit.'*

## Fix

1. Recognize `iteration-start` / `loop-start` node types.
2. Propagate reachability into containers via `parentId`/`iteration_id` to a fixpoint (handles nesting).
3. Exempt scoped var refs in three legitimate directions: container→inner (output_selector), inner→container (scoped item/index), sibling→sibling (same container).

## Verification

- Structure verified against a real Dify DSL export (iteration node with `iterator_selector`/`output_selector`/`start_node_id`, `custom-iteration-start` child, inner nodes with `parentId`+`iteration_id`).
- Added a regression test with the real iteration structure (RED-GREEN confirmed: reverting the reachability fix fails it).
- Full suite: 55/55 pass. `tsc --noEmit` clean.
- Confirmed end-to-end against a self-hosted Dify: a workflow with two iteration containers (mastery + weakness fan-out over dynamic arrays) now validates, syncs, and runs `succeeded`.