### PR TITLE
feat(workflow): manage workflow-tool providers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thanks for your interest in dify-mcp! This is a community project - contribution
 git clone https://github.com/alexjiaguo/dify-mcp.git
 cd dify-mcp
 npm install
-npm test              # 42 unit tests
+npm test              # 49 unit tests
 npm run typecheck     # tsc --noEmit
 npm run smoke:mcp     # MCP stdio smoke
 ```

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ difywf auth import-cookies --base-url https://cloud.dify.ai --file cookies.json
 # Or self-hosted with email/password (no browser needed):
 difywf auth login-console --base-url https://your-dify --email you@x --password '***'
 
+# Non-interactive bootstrap can keep credentials out of process arguments:
+DIFY_CONSOLE_EMAIL=you@x DIFY_CONSOLE_PASSWORD='***' \
+  difywf auth login-console --base-url https://your-dify
+
 difywf auth status   # confirm: shows base URL + cookie names (values masked)
 ```
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ difywf auth login-console --base-url https://your-dify --email you@x --password 
 DIFY_CONSOLE_EMAIL=you@x DIFY_CONSOLE_PASSWORD='***' \
   difywf auth login-console --base-url https://your-dify
 
+# Deployments whose login endpoint expects the legacy encoded payload:
+DIFY_CONSOLE_EMAIL=you@x DIFY_CONSOLE_PASSWORD='***' \
+  DIFY_CONSOLE_PASSWORD_ENCODING=base64 \
+  difywf auth login-console --base-url https://your-dify
+
 difywf auth status   # confirm: shows base URL + cookie names (values masked)
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 ### The most complete MCP server + CLI for [Dify](https://github.com/langgenius/dify)
 
-**141 tools. 16 namespaces. One registry.** Let any AI agent build, test, and ship
+**143 tools. 16 namespaces. One registry.** Let any AI agent build, test, and ship
 Dify workflows autonomously — everything a human can do in the UI, now scriptable.
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Node >= 23.6](https://img.shields.io/badge/node-%E2%89%A523.6-green.svg)](https://nodejs.org)
-[![141 Tools](https://img.shields.io/badge/tools-141-purple.svg)](#tools)
+[![143 Tools](https://img.shields.io/badge/tools-143-purple.svg)](#tools)
 [![Live Verified](https://img.shields.io/badge/live--verified-cloud.dify.ai-brightgreen.svg)](#live-verified)
 
 Works with **Claude Code** · **Codex** · **Gemini CLI** · **Cursor** · **Cline** · **Windsurf** · **Roo Code** · **Continue** · **Aider** · **Zed** — and any other MCP-compatible or shell-capable agent.
@@ -26,7 +26,7 @@ create workflows, wire up nodes, test them, iterate, and publish — without a b
 
 **dify-mcp** is the bridge. It exposes the **entire Dify console API** as a unified
 tool registry with **two surfaces**: a CLI any shell-capable agent can drive, and an
-MCP server (stdio or Streamable HTTP) any MCP-compatible host can attach. Same 141 tools, same JSON
+MCP server (stdio or Streamable HTTP) any MCP-compatible host can attach. Same 143 tools, same JSON
 contract, same safety guarantees.
 
 ```
@@ -34,7 +34,7 @@ contract, same safety guarantees.
 │                    dify-mcp                              │
 │                                                          │
 │   ┌──────────┐    ┌────────────────────┐    ┌─────────┐ │
-│   │  CLI     │───▶│   141-tool         │───▶│  Dify   │ │
+│   │  CLI     │───▶│   143-tool         │───▶│  Dify   │ │
 │   │  difywf  │    │   registry         │    │  API    │ │
 │   └──────────┘    │                    │    └─────────┘ │
 │   ┌──────────┐    │  app · workflow    │         ▲      │
@@ -99,7 +99,7 @@ Every tool category has been tested against **cloud.dify.ai** with real credenti
 - ✅ All 16 namespaces exercised: apps, workflows, providers, plugins, triggers,
   snippets, RAG, agents, stats, comments, annotations, audio, files, runs, workspace
 - ✅ MCP transport: `tools/call` over stdio and Streamable HTTP with live cookie auth
-- ✅ Unit tests · typecheck clean · MCP smoke (141 tools)
+- ✅ Unit tests · typecheck clean · MCP smoke (143 tools)
 
 ## Quickstart
 
@@ -154,7 +154,7 @@ difywf workflow tool refresh-provider <app-id> --yes        # rebind workflow-as
 
 ### Connect your agent (MCP)
 
-Same binary, same 141 tools. Copy-paste the config for your host:
+Same binary, same 143 tools. Copy-paste the config for your host:
 
 <details>
 <summary><b>Claude Code</b></summary>
@@ -279,12 +279,12 @@ store instead of putting tokens in the image.
 
 ## Tools
 
-**141 tools across 16 namespaces.** Run `difywf --help` for the full live list, or
+**143 tools across 16 namespaces.** Run `difywf --help` for the full live list, or
 `difywf agent guide` for the agent-oriented playbook.
 
 | Namespace | Tools | What it does |
 |-----------|-------|-------------|
-| `app` | 13 | List, create, update, delete, export, import, copy, rename, convert apps |
+| `app` | 15 | List, create, update, tag, delete, export, import, copy, rename, convert apps |
 | `workflow` | 25 | Get/sync drafts, validate, run, publish, workflow-tool providers, node defaults, variables, versions, HITL |
 | `provider` | 3 | List providers, list models, set credentials |
 | `plugin` | 1 | List installed plugins |
@@ -322,7 +322,7 @@ before retrying.
 ```bash
 npm run typecheck   # tsc --noEmit
 npm test            # 49 unit tests
-npm run smoke:mcp   # MCP stdio smoke (141 tools, JSON-RPC handshake)
+npm run smoke:mcp   # MCP stdio smoke (143 tools, JSON-RPC handshake)
 npm run smoke:mcp:http   # MCP Streamable HTTP smoke (stateless POST /mcp)
 ```
 

--- a/README.md
+++ b/README.md
@@ -239,8 +239,9 @@ For remote or containerized hosts that can't spawn a local process, run the MCP
 server over the stateless Streamable HTTP transport:
 
 ```bash
-difywf mcp serve --http --port 8080
-# or via env: DIFYWF_MCP_TRANSPORT=http DIFYWF_MCP_PORT=8080 difywf mcp serve
+difywf mcp serve --http --host 127.0.0.1 --port 8080
+# or via env: DIFYWF_MCP_TRANSPORT=http DIFYWF_MCP_HOST=127.0.0.1 \
+#             DIFYWF_MCP_PORT=8080 difywf mcp serve
 ```
 
 Point any Streamable-HTTP-capable client at `http://<host>:8080/mcp`. Each POST is

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ difywf wf validate --graph graph.json       # offline: structure, refs, cycles
 difywf wf draft sync <app-id> --graph graph.json --dry-run   # preview diff
 difywf wf draft sync <app-id> --graph graph.json             # save draft
 difywf wf test <app-id> --input query="hello"                # test-run the draft
+difywf app import --yaml @workflow.yml --yes                  # file channel for large DSLs
 difywf wf publish <app-id> --yes                             # ship it
 difywf workflow tool refresh-provider <app-id> --yes        # rebind workflow-as-tool to the published version
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Don't see your agent? If it supports MCP or can run shell commands, it works. Th
 - **Agent-agnostic by design.** No SDK lock-in. The CLI works with any agent that
   can run a shell command. The MCP server works with any MCP host. Both return
   structured JSON — `{ ok, data }` or `{ ok: false, error: { code, message, retryable } }`
-  — so agents never scrape human-readable text.
+  — so agents never scrape human-readable text. For large drafts and exports, the CLI's
+  `--output-file <path>` keeps the full UTF-8 result off size-limited stdout transports.
 
 - **Cookie auth, handled.** Dify's console uses cookie + CSRF double-submit, not
   Bearer tokens. dify-mcp captures, stores, and auto-refreshes the session — including

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 ### The most complete MCP server + CLI for [Dify](https://github.com/langgenius/dify)
 
-**138 tools. 16 namespaces. One registry.** Let any AI agent build, test, and ship
+**141 tools. 16 namespaces. One registry.** Let any AI agent build, test, and ship
 Dify workflows autonomously — everything a human can do in the UI, now scriptable.
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Node >= 23.6](https://img.shields.io/badge/node-%E2%89%A523.6-green.svg)](https://nodejs.org)
-[![138 Tools](https://img.shields.io/badge/tools-138-purple.svg)](#tools)
+[![141 Tools](https://img.shields.io/badge/tools-141-purple.svg)](#tools)
 [![Live Verified](https://img.shields.io/badge/live--verified-cloud.dify.ai-brightgreen.svg)](#live-verified)
 
 Works with **Claude Code** · **Codex** · **Gemini CLI** · **Cursor** · **Cline** · **Windsurf** · **Roo Code** · **Continue** · **Aider** · **Zed** — and any other MCP-compatible or shell-capable agent.
@@ -26,7 +26,7 @@ create workflows, wire up nodes, test them, iterate, and publish — without a b
 
 **dify-mcp** is the bridge. It exposes the **entire Dify console API** as a unified
 tool registry with **two surfaces**: a CLI any shell-capable agent can drive, and an
-MCP server (stdio or Streamable HTTP) any MCP-compatible host can attach. Same 138 tools, same JSON
+MCP server (stdio or Streamable HTTP) any MCP-compatible host can attach. Same 141 tools, same JSON
 contract, same safety guarantees.
 
 ```
@@ -34,7 +34,7 @@ contract, same safety guarantees.
 │                    dify-mcp                              │
 │                                                          │
 │   ┌──────────┐    ┌────────────────────┐    ┌─────────┐ │
-│   │  CLI     │───▶│   138-tool         │───▶│  Dify   │ │
+│   │  CLI     │───▶│   141-tool         │───▶│  Dify   │ │
 │   │  difywf  │    │   registry         │    │  API    │ │
 │   └──────────┘    │                    │    └─────────┘ │
 │   ┌──────────┐    │  app · workflow    │         ▲      │
@@ -99,7 +99,7 @@ Every tool category has been tested against **cloud.dify.ai** with real credenti
 - ✅ All 16 namespaces exercised: apps, workflows, providers, plugins, triggers,
   snippets, RAG, agents, stats, comments, annotations, audio, files, runs, workspace
 - ✅ MCP transport: `tools/call` over stdio and Streamable HTTP with live cookie auth
-- ✅ 42 unit tests · typecheck clean · MCP smoke (138 tools)
+- ✅ Unit tests · typecheck clean · MCP smoke (141 tools)
 
 ## Quickstart
 
@@ -140,11 +140,12 @@ difywf wf draft sync <app-id> --graph graph.json --dry-run   # preview diff
 difywf wf draft sync <app-id> --graph graph.json             # save draft
 difywf wf test <app-id> --input query="hello"                # test-run the draft
 difywf wf publish <app-id> --yes                             # ship it
+difywf workflow tool refresh-provider <app-id> --yes        # rebind workflow-as-tool to the published version
 ```
 
 ### Connect your agent (MCP)
 
-Same binary, same 138 tools. Copy-paste the config for your host:
+Same binary, same 141 tools. Copy-paste the config for your host:
 
 <details>
 <summary><b>Claude Code</b></summary>
@@ -268,13 +269,13 @@ store instead of putting tokens in the image.
 
 ## Tools
 
-**138 tools across 16 namespaces.** Run `difywf --help` for the full live list, or
+**141 tools across 16 namespaces.** Run `difywf --help` for the full live list, or
 `difywf agent guide` for the agent-oriented playbook.
 
 | Namespace | Tools | What it does |
 |-----------|-------|-------------|
 | `app` | 13 | List, create, update, delete, export, import, copy, rename, convert apps |
-| `workflow` | 22 | Get/sync drafts, validate, run, publish, node defaults, variables, versions, HITL |
+| `workflow` | 25 | Get/sync drafts, validate, run, publish, workflow-tool providers, node defaults, variables, versions, HITL |
 | `provider` | 3 | List providers, list models, set credentials |
 | `plugin` | 1 | List installed plugins |
 | `trigger` | 4 | Create, enable, list, webhook triggers; run triggers |
@@ -310,8 +311,8 @@ before retrying.
 
 ```bash
 npm run typecheck   # tsc --noEmit
-npm test            # 42 unit tests
-npm run smoke:mcp   # MCP stdio smoke (138 tools, JSON-RPC handshake)
+npm test            # 49 unit tests
+npm run smoke:mcp   # MCP stdio smoke (141 tools, JSON-RPC handshake)
 npm run smoke:mcp:http   # MCP Streamable HTTP smoke (stateless POST /mcp)
 ```
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ store instead of putting tokens in the image.
 
 | Namespace | Tools | What it does |
 |-----------|-------|-------------|
-| `app` | 15 | List, create, update, tag, delete, export, import, copy, rename, convert apps |
+| `app` | 16 | List, create, update, tag, untag, delete, export, import, copy, rename, convert apps |
 | `workflow` | 25 | Get/sync drafts, validate, run, publish, workflow-tool providers, node defaults, variables, versions, HITL |
 | `provider` | 3 | List providers, list models, set credentials |
 | `plugin` | 1 | List installed plugins |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dify-mcp",
   "version": "0.1.0",
-  "description": "The most complete Dify MCP server + CLI \u2014 138 tools that let any AI agent build, test & ship Dify workflows autonomously",
+  "description": "The most complete Dify MCP server + CLI \u2014 141 tools that let any AI agent build, test & ship Dify workflows autonomously",
   "type": "module",
   "bin": {
     "difywf": "bin/difywf.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dify-mcp",
   "version": "0.1.0",
-  "description": "The most complete Dify MCP server + CLI \u2014 141 tools that let any AI agent build, test & ship Dify workflows autonomously",
+  "description": "The most complete Dify MCP server + CLI \u2014 143 tools that let any AI agent build, test & ship Dify workflows autonomously",
   "type": "module",
   "bin": {
     "difywf": "bin/difywf.js"

--- a/scripts/mcp-smoke-http.mjs
+++ b/scripts/mcp-smoke-http.mjs
@@ -1,6 +1,7 @@
 // MCP Streamable HTTP smoke test: start the server in --http mode, then run
 // initialize -> tools/list -> tools/call against POST /mcp (stateless).
 import { spawn } from "node:child_process";
+import assert from "node:assert/strict";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -59,7 +60,7 @@ try {
   const listRes = await readResult(list);
   const names = (listRes?.result?.tools ?? []).map((t) => t.name);
   if (names.length < 15) fail(`expected >=15 tools, got ${names.length}`);
-  for (const req of ["agent_guide", "workflow_validate", "workflow_sync_draft", "app_create"]) {
+  for (const req of ["agent_guide", "workflow_validate", "workflow_sync_draft", "workflow_tool_refresh_provider", "app_create"]) {
     if (!names.includes(req)) fail(`missing tool ${req}`);
   }
   console.log(`tools/list OK (${names.length} tools)`);

--- a/scripts/mcp-smoke.mjs
+++ b/scripts/mcp-smoke.mjs
@@ -53,7 +53,7 @@ notify("notifications/initialized");
 const list = await send("tools/list", {});
 const names = (list?.tools ?? []).map((t) => t.name);
 if (names.length < 15) fail(`expected >=15 tools, got ${names.length}`);
-for (const required of ["agent_guide", "workflow_validate", "workflow_sync_draft", "workflow_publish", "app_create"]) {
+for (const required of ["agent_guide", "workflow_validate", "workflow_sync_draft", "workflow_publish", "workflow_tool_refresh_provider", "app_create"]) {
   if (!names.includes(required)) fail(`missing tool ${required}`);
 }
 console.log(`tools/list OK (${names.length} tools)`);

--- a/src/api/console.ts
+++ b/src/api/console.ts
@@ -88,6 +88,69 @@ export class ConsoleClient {
     return this.call(`apps/${appId}/workflows/publish`, { body });
   }
 
+  // --- workflow-as-tool providers ---
+  async getWorkflowTool(q: { appId?: string; toolId?: string }): Promise<Result<Record<string, unknown>>> {
+    const result = await this.call<Record<string, unknown>>("workspaces/current/tool-provider/workflow/get", {
+      query: { workflow_app_id: q.appId, workflow_tool_id: q.toolId },
+    });
+    // Dify versions have returned both 404 and 400/500 + "Tool not found" for
+    // this lookup. Normalize all of them to the stable NOT_FOUND contract.
+    if (!result.ok && /tool not found/i.test(result.error.message)) {
+      return err("NOT_FOUND", result.error.message, { details: result.error.details });
+    }
+    return result;
+  }
+  createWorkflowTool(body: Record<string, unknown>): Promise<Result<unknown>> {
+    return this.call("workspaces/current/tool-provider/workflow/create", { body });
+  }
+  updateWorkflowTool(body: Record<string, unknown>): Promise<Result<unknown>> {
+    return this.call("workspaces/current/tool-provider/workflow/update", { body });
+  }
+  deleteWorkflowTool(toolId: string): Promise<Result<unknown>> {
+    return this.call("workspaces/current/tool-provider/workflow/delete", {
+      body: { workflow_tool_id: toolId },
+    });
+  }
+  async refreshWorkflowToolProvider(appId: string): Promise<Result<unknown>> {
+    const current = await this.getWorkflowTool({ appId });
+    if (!current.ok && current.error.code !== "NOT_FOUND") return current;
+    if (current.ok && current.data.synced === true) {
+      return ok({ action: "unchanged", before: current.data, after: current.data });
+    }
+
+    const [app, draft] = await Promise.all([this.getApp(appId), this.getDraft(appId)]);
+    if (!app.ok) return app;
+    if (!draft.ok) return draft;
+    const existing = current.ok ? current.data : undefined;
+    const body = buildWorkflowToolPayload(
+      app.data as Record<string, unknown>,
+      draft.data as Record<string, unknown>,
+      existing,
+    );
+
+    let mutation: Result<unknown>;
+    let action: "created" | "updated";
+    if (existing) {
+      const toolId = nonEmptyString(existing.workflow_tool_id);
+      if (!toolId) return err("SERVER_ERROR", "workflow tool detail is missing workflow_tool_id");
+      action = "updated";
+      mutation = await this.updateWorkflowTool({ ...body, workflow_tool_id: toolId });
+    } else {
+      action = "created";
+      mutation = await this.createWorkflowTool({ ...body, workflow_app_id: appId });
+    }
+    if (!mutation.ok) return mutation;
+
+    const after = await this.getWorkflowTool({ appId });
+    if (!after.ok) return after;
+    if (after.data.synced !== true) {
+      return err("DSL_VERSION_MISMATCH", `workflow tool provider for app ${appId} is still out of sync`, {
+        details: { action, before: existing ?? null, after: after.data },
+      });
+    }
+    return ok({ action, before: existing ?? null, after: after.data });
+  }
+
   // --- testing ---
   runDraft(appId: string, inputs: Record<string, unknown>): Promise<Result<unknown[]>> {
     return readSse(`${this.base}/console/api`, `apps/${appId}/workflows/draft/run`, this.authOpts({ body: { inputs } }));
@@ -493,4 +556,92 @@ export class ConsoleClient {
   agentSandboxUpload(agentId: string, body: Record<string, unknown>): Promise<Result<unknown>> {
     return this.call(`agent/${agentId}/sandbox/files/upload`, { body });
   }
+}
+
+function buildWorkflowToolPayload(
+  app: Record<string, unknown>,
+  draft: Record<string, unknown>,
+  existing?: Record<string, unknown>,
+): Record<string, unknown> {
+  const appName = nonEmptyString(app.name) ?? "Workflow Tool";
+  const label = nonEmptyString(existing?.label) ?? appName;
+  const existingParameters = new Map<string, Record<string, unknown>>();
+  if (Array.isArray(existing?.parameters)) {
+    for (const item of existing.parameters) {
+      if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+      const parameter = item as Record<string, unknown>;
+      const name = nonEmptyString(parameter.name);
+      if (name) existingParameters.set(name, parameter);
+    }
+  }
+
+  return {
+    name: nonEmptyString(existing?.name) ?? safeWorkflowToolName(label),
+    label,
+    description: typeof existing?.description === "string"
+      ? existing.description
+      : (typeof app.description === "string" ? app.description : ""),
+    icon: workflowToolIcon(app, existing),
+    parameters: workflowStartVariableNames(draft).map((name) => {
+      const previous = existingParameters.get(name);
+      return {
+        name,
+        description: typeof previous?.description === "string" ? previous.description : "",
+        form: typeof previous?.form === "string" ? previous.form : "form",
+      };
+    }),
+    labels: workflowToolLabels(existing),
+    privacy_policy: typeof existing?.privacy_policy === "string" ? existing.privacy_policy : "",
+  };
+}
+
+function workflowStartVariableNames(draft: Record<string, unknown>): string[] {
+  const graph = draft.graph;
+  if (!graph || typeof graph !== "object" || Array.isArray(graph)) return [];
+  const nodes = (graph as Record<string, unknown>).nodes;
+  if (!Array.isArray(nodes)) return [];
+  for (const item of nodes) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const data = (item as Record<string, unknown>).data;
+    if (!data || typeof data !== "object" || Array.isArray(data)) continue;
+    const node = data as Record<string, unknown>;
+    if (node.type !== "start" || !Array.isArray(node.variables)) continue;
+    return node.variables
+      .map((variable) => variable && typeof variable === "object" && !Array.isArray(variable)
+        ? nonEmptyString((variable as Record<string, unknown>).variable)
+          ?? nonEmptyString((variable as Record<string, unknown>).name)
+        : undefined)
+      .filter((name): name is string => Boolean(name));
+  }
+  return [];
+}
+
+function workflowToolIcon(
+  app: Record<string, unknown>,
+  existing?: Record<string, unknown>,
+): Record<string, string> {
+  if (existing?.icon && typeof existing.icon === "object" && !Array.isArray(existing.icon)) {
+    return existing.icon as Record<string, string>;
+  }
+  return {
+    content: nonEmptyString(app.icon) ?? "\ud83d\udd27",
+    background: nonEmptyString(app.icon_background) ?? "#FFEAD5",
+  };
+}
+
+function workflowToolLabels(existing?: Record<string, unknown>): string[] {
+  const tool = existing?.tool;
+  if (!tool || typeof tool !== "object" || Array.isArray(tool)) return [];
+  const labels = (tool as Record<string, unknown>).labels;
+  return Array.isArray(labels) ? labels.filter((label): label is string => typeof label === "string") : [];
+}
+
+function safeWorkflowToolName(label: string): string {
+  let name = label.replace(/[^A-Za-z0-9_]+/g, "_").replace(/_{3,}/g, "_").replace(/^_+|_+$/g, "");
+  if (!name) name = "workflow_tool";
+  return /^\d/.test(name) ? `tool_${name}` : name;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value ? value : undefined;
 }

--- a/src/api/console.ts
+++ b/src/api/console.ts
@@ -66,6 +66,76 @@ export class ConsoleClient {
   deleteApp(appId: string): Promise<Result<unknown>> {
     return this.call(`apps/${appId}`, { method: "DELETE" });
   }
+  async getAppTags(appId: string): Promise<Result<{ app_id: string; tags: Array<{ id?: string; name: string }> }>> {
+    const app = await this.getApp(appId);
+    if (!app.ok) return app;
+    const raw = (app.data as Record<string, unknown>).tags;
+    const tags = Array.isArray(raw)
+      ? raw.flatMap((item) => {
+          if (!item || typeof item !== "object") return [];
+          const value = item as Record<string, unknown>;
+          const name = nonEmptyString(value.name);
+          if (!name) return [];
+          const id = nonEmptyString(value.id);
+          return [{ ...(id ? { id } : {}), name }];
+        })
+      : [];
+    return ok({ app_id: appId, tags });
+  }
+  listAppTags(): Promise<Result<unknown>> {
+    return this.call("tags", { query: { type: "app" } });
+  }
+  createAppTag(name: string): Promise<Result<unknown>> {
+    return this.call("tags", { body: { name, type: "app" } });
+  }
+  bindAppTag(appId: string, tagId: string): Promise<Result<unknown>> {
+    return this.call("tag-bindings", {
+      body: { tag_ids: [tagId], target_id: appId, type: "app" },
+    });
+  }
+  async ensureAppTag(appId: string, tagName: string): Promise<Result<unknown>> {
+    const before = await this.getAppTags(appId);
+    if (!before.ok) return before;
+    const existing = before.data.tags.find((tag) => tag.name === tagName);
+    if (existing) {
+      return ok({ action: "unchanged", app_id: appId, tag: existing, after: before.data.tags });
+    }
+
+    const listed = await this.listAppTags();
+    if (!listed.ok) return listed;
+    const rows = Array.isArray(listed.data) ? listed.data : [];
+    let tagId: string | undefined;
+    for (const item of rows) {
+      if (!item || typeof item !== "object") continue;
+      const value = item as Record<string, unknown>;
+      if (value.name === tagName) tagId = nonEmptyString(value.id);
+    }
+    let created = false;
+    if (!tagId) {
+      const added = await this.createAppTag(tagName);
+      if (!added.ok) return added;
+      tagId = nonEmptyString((added.data as Record<string, unknown> | null)?.id);
+      if (!tagId) return err("SERVER_ERROR", "created app tag response is missing id");
+      created = true;
+    }
+
+    const bound = await this.bindAppTag(appId, tagId);
+    if (!bound.ok) return bound;
+    const after = await this.getAppTags(appId);
+    if (!after.ok) return after;
+    const readback = after.data.tags.find((tag) => tag.name === tagName);
+    if (!readback) {
+      return err("DSL_VERSION_MISMATCH", `app tag ${tagName} is missing after bind readback`, {
+        details: { app_id: appId, tag_id: tagId, after: after.data.tags },
+      });
+    }
+    return ok({
+      action: created ? "created_and_bound" : "bound",
+      app_id: appId,
+      tag: readback,
+      after: after.data.tags,
+    });
+  }
 
   // --- workspaces ---
   listWorkspaces(): Promise<Result<unknown>> {

--- a/src/api/console.ts
+++ b/src/api/console.ts
@@ -57,6 +57,12 @@ export class ConsoleClient {
     const r = await this.call<{ data: string }>(`apps/${appId}/export`);
     return r.ok ? ok(r.data.data) : r;
   }
+  importDsl(payload: Record<string, unknown>): Promise<Result<unknown>> {
+    return this.call("apps/imports", { body: payload });
+  }
+  confirmImport(importId: string): Promise<Result<unknown>> {
+    return this.call(`apps/imports/${importId}/confirm`, { body: {} });
+  }
   createApp(body: Record<string, unknown>): Promise<Result<unknown>> {
     return this.call("apps", { body });
   }

--- a/src/api/console.ts
+++ b/src/api/console.ts
@@ -99,6 +99,11 @@ export class ConsoleClient {
       body: { tag_ids: [tagId], target_id: appId, type: "app" },
     });
   }
+  removeAppTagBinding(appId: string, tagId: string): Promise<Result<unknown>> {
+    return this.call("tag-bindings/remove", {
+      body: { tag_ids: [tagId], target_id: appId, type: "app" },
+    });
+  }
   async ensureAppTag(appId: string, tagName: string): Promise<Result<unknown>> {
     const before = await this.getAppTags(appId);
     if (!before.ok) return before;
@@ -139,6 +144,43 @@ export class ConsoleClient {
       action: created ? "created_and_bound" : "bound",
       app_id: appId,
       tag: readback,
+      after: after.data.tags,
+    });
+  }
+  async removeAppTag(appId: string, tagName: string): Promise<Result<unknown>> {
+    const before = await this.getAppTags(appId);
+    if (!before.ok) return before;
+    const existing = before.data.tags.find((tag) => tag.name === tagName);
+    if (!existing) {
+      return ok({ action: "unchanged", app_id: appId, tag: tagName, after: before.data.tags });
+    }
+
+    let tagId = existing.id;
+    if (!tagId) {
+      const listed = await this.listAppTags();
+      if (!listed.ok) return listed;
+      const rows = Array.isArray(listed.data) ? listed.data : [];
+      for (const item of rows) {
+        if (!item || typeof item !== "object") continue;
+        const value = item as Record<string, unknown>;
+        if (value.name === tagName) tagId = nonEmptyString(value.id);
+      }
+    }
+    if (!tagId) return err("SERVER_ERROR", `app tag ${tagName} has no resolvable id`);
+
+    const removed = await this.removeAppTagBinding(appId, tagId);
+    if (!removed.ok) return removed;
+    const after = await this.getAppTags(appId);
+    if (!after.ok) return after;
+    if (after.data.tags.some((tag) => tag.name === tagName)) {
+      return err("DSL_VERSION_MISMATCH", `app tag ${tagName} remains after unbind readback`, {
+        details: { app_id: appId, tag_id: tagId, after: after.data.tags },
+      });
+    }
+    return ok({
+      action: "removed",
+      app_id: appId,
+      tag: { id: tagId, name: tagName },
       after: after.data.tags,
     });
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ const CMD_ALIASES: Record<string, string> = {
   "workflow node run": "workflow.run_node",
 };
 const POSITIONALS: Record<string, string[]> = {
-  "app.get": ["app_id"], "app.update": ["app_id"], "app.delete": ["app_id"], "app.export": ["app_id"],
+  "app.get": ["app_id"], "app.update": ["app_id"], "app.list_tags": ["app_id"], "app.ensure_tag": ["app_id", "tag"], "app.delete": ["app_id"], "app.export": ["app_id"],
   "workflow.get_draft": ["app_id"], "workflow.node_defaults": ["app_id", "node_type"], "workflow.sync_draft": ["app_id"],
   "workflow.run_draft": ["app_id"], "workflow.run": ["app_id"], "workflow.publish": ["app_id"],
   "workflow.run_node": ["app_id", "node_id"], "workflow.events": ["app_id", "task_id"], "workflow.stop": ["app_id", "task_id"],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,7 +66,10 @@ const POSITIONALS: Record<string, string[]> = {
   "agent.sandbox_info": ["agent_id"], "agent.sandbox_files": ["agent_id"], "agent.sandbox_read": ["agent_id"], "agent.sandbox_upload": ["agent_id"],
   "agent.guide": ["section"],
 };
-const CONTROL_FLAGS = new Set(["o", "output", "help", "h", "version", "base-url", "workspace", "openapi-token", "console-token"]);
+const CONTROL_FLAGS = new Set([
+  "o", "output", "output-file", "help", "h", "version", "base-url", "workspace",
+  "openapi-token", "console-token",
+]);
 
 export function parseFlags(argv: string[]): { positional: string[]; flags: Record<string, unknown> } {
   const positional: string[] = [];
@@ -297,6 +300,13 @@ async function authMain(args: string[], flags: Record<string, unknown>): Promise
 
 function finish(result: Result<unknown>, flags: Record<string, unknown>): void {
   const format = String(flags.o ?? flags.output ?? "json");
+  const outputFile = str(flags["output-file"]);
+  if (outputFile) {
+    const rendered = format === "yaml" ? toYaml(result) + "\n" : JSON.stringify(result) + "\n";
+    fs.writeFileSync(outputFile, rendered, { encoding: "utf8" });
+    process.stdout.write(JSON.stringify({ ok: true, output_file: outputFile }) + "\n");
+    process.exit(result.ok ? EXIT.OK : EXIT[result.error.code]);
+  }
   if (format === "yaml") {
     process.stdout.write(toYaml(result) + "\n");
   } else if (format === "text") {
@@ -330,6 +340,7 @@ function printHelp(positional: string[]): void {
     "",
     "GLOBAL FLAGS",
     "  -o, --output json|yaml|text   output format (default json; MCP always json)",
+    "  --output-file <path>          write the full result to a file; stdout returns a small acknowledgement",
     "  --base-url <url>              Dify base URL (or DIFY_API_BASE)",
     "  --workspace <id>              workspace id (or DIFY_WORKSPACE_ID)",
     "  --openapi-token / --console-token   tokens (or DIFY_OPENAPI_TOKEN / DIFY_CONSOLE_TOKEN)",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,11 @@ import { runTool, tools } from "./tools/registry.ts";
 
 const VERSION = "0.1.0";
 
-const NS_ALIASES: Record<string, string> = { wf: "workflow", providers: "provider", plugins: "plugin" };
+const NS_ALIASES: Record<string, string> = {
+  wf: "workflow",
+  providers: "provider",
+  plugins: "plugin",
+};
 const CMD_ALIASES: Record<string, string> = {
   "workflow test": "workflow.run_draft",
   "workflow draft get": "workflow.get_draft",
@@ -23,6 +27,7 @@ const POSITIONALS: Record<string, string[]> = {
   "workflow.get_draft": ["app_id"], "workflow.node_defaults": ["app_id", "node_type"], "workflow.sync_draft": ["app_id"],
   "workflow.run_draft": ["app_id"], "workflow.run": ["app_id"], "workflow.publish": ["app_id"],
   "workflow.run_node": ["app_id", "node_id"], "workflow.events": ["app_id", "task_id"], "workflow.stop": ["app_id", "task_id"],
+  "workflow.tool_get": ["app_id"], "workflow.tool_refresh_provider": ["app_id"], "workflow.tool_delete": ["workflow_tool_id"],
   "provider.models": ["provider"],
   "workflow.get_features": ["app_id"], "workflow.set_features": ["app_id"],
   "workflow.list_env_vars": ["app_id"], "workflow.list_conv_vars": ["app_id"],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -176,6 +176,7 @@ function buildArgs(flags: Record<string, unknown>): Record<string, unknown> {
     else if (k === "input") args.inputs = kvList(v, "input");
     else if (k === "graph") args.graph = readJsonArg(v, "graph");
     else if (k === "graph-json") args.graph_json = String(v);
+    else if (k === "yaml") args.yaml = readTextArg(v, "yaml");
     else if (k === "credentials") args.credentials = readJsonArg(v, "credentials");
     else if (k === "app-id") args.app_id = v;
     else if (k === "node-id") args.node_id = v;
@@ -185,6 +186,18 @@ function buildArgs(flags: Record<string, unknown>): Record<string, unknown> {
     else args[k.replaceAll("-", "_")] = typeof v === "string" && (v.startsWith("{") || v.startsWith("[")) ? readJsonArg(v, k) : v;
   }
   return args;
+}
+
+// Large DSLs exceed the operating system's per-argument limit. Keep literal
+// YAML backward compatible while allowing the same explicit @file/stdin
+// channel already used by --graph.
+export function readTextArg(value: unknown, name: string): string {
+  const s = String(value);
+  if (s === "-") return fs.readFileSync(0, "utf8");
+  if (!s.startsWith("@")) return s;
+  const p = s.slice(1);
+  if (!fs.existsSync(p)) throw new Error(`--${name}: file not found: ${p}`);
+  return fs.readFileSync(p, "utf8");
 }
 
 // --graph/--credentials accept: "-" (stdin), "@file"/path, or an inline JSON string.
@@ -349,6 +362,7 @@ function printHelp(positional: string[]): void {
     "  --yes                         confirm destructive ops (maps to confirm=true)",
     "  --dry-run                     validate + diff without saving",
     "  --graph <file|-|{json}>       graph input: file, stdin, or inline JSON",
+    "  --yaml <@file|-|yaml>         app-import DSL: explicit file, stdin, or inline YAML",
     "  --input k=v                   workflow input (repeatable)",
     "",
     "Start with: difywf agent guide",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,10 +108,17 @@ export function parseFlags(argv: string[]): { positional: string[]; flags: Recor
 export function resolveConsoleLoginCredentials(
   flags: Record<string, unknown>,
   env: NodeJS.ProcessEnv = process.env,
-): { email?: string; password?: string } {
+): { email?: string; password?: string; passwordEncoding: "plain" | "base64" } {
+  const rawEncoding = str(flags["password-encoding"])
+    ?? str(env.DIFY_CONSOLE_PASSWORD_ENCODING)
+    ?? "plain";
+  if (rawEncoding !== "plain" && rawEncoding !== "base64") {
+    throw new Error("password encoding must be 'plain' or 'base64'");
+  }
   return {
     email: str(flags.email) ?? str(env.DIFY_CONSOLE_EMAIL),
     password: str(flags.password) ?? str(env.DIFY_CONSOLE_PASSWORD),
+    passwordEncoding: rawEncoding,
   };
 }
 
@@ -238,7 +245,13 @@ async function authMain(args: string[], flags: Record<string, unknown>): Promise
     }
     case "login-console": {
       const base = needBase();
-      const { email, password } = resolveConsoleLoginCredentials(flags);
+      let credentials: ReturnType<typeof resolveConsoleLoginCredentials>;
+      try {
+        credentials = resolveConsoleLoginCredentials(flags);
+      } catch (e) {
+        return finish(err("USAGE_ERROR", e instanceof Error ? e.message : String(e)), flags);
+      }
+      const { email, password, passwordEncoding } = credentials;
       if (!email || !password) {
         return finish(
           err(
@@ -248,7 +261,7 @@ async function authMain(args: string[], flags: Record<string, unknown>): Promise
           flags,
         );
       }
-      const result = await consoleLogin(base, email, password);
+      const result = await consoleLogin(base, email, password, passwordEncoding);
       if (result.ok) storeCookies(base, result.data);
       return finish(result.ok ? { ok: true, data: { stored: true, base_url: base, cookies: Object.keys(result.data) } } : (result as Result<unknown>), flags);
     }
@@ -321,6 +334,7 @@ function printHelp(positional: string[]): void {
     "  --workspace <id>              workspace id (or DIFY_WORKSPACE_ID)",
     "  --openapi-token / --console-token   tokens (or DIFY_OPENAPI_TOKEN / DIFY_CONSOLE_TOKEN)",
     "  --email / --password            console login (or DIFY_CONSOLE_EMAIL / DIFY_CONSOLE_PASSWORD)",
+    "  --password-encoding <plain|base64>  login payload encoding (or DIFY_CONSOLE_PASSWORD_ENCODING)",
     "  --yes                         confirm destructive ops (maps to confirm=true)",
     "  --dry-run                     validate + diff without saving",
     "  --graph <file|-|{json}>       graph input: file, stdin, or inline JSON",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,6 +105,16 @@ export function parseFlags(argv: string[]): { positional: string[]; flags: Recor
   return { positional, flags };
 }
 
+export function resolveConsoleLoginCredentials(
+  flags: Record<string, unknown>,
+  env: NodeJS.ProcessEnv = process.env,
+): { email?: string; password?: string } {
+  return {
+    email: str(flags.email) ?? str(env.DIFY_CONSOLE_EMAIL),
+    password: str(flags.password) ?? str(env.DIFY_CONSOLE_PASSWORD),
+  };
+}
+
 export async function main(): Promise<void> {
   const { positional, flags } = parseFlags(process.argv.slice(2));
   if (flags.version === true || positional[0] === "version") return printRaw(VERSION);
@@ -228,9 +238,16 @@ async function authMain(args: string[], flags: Record<string, unknown>): Promise
     }
     case "login-console": {
       const base = needBase();
-      const email = str(flags.email);
-      const password = str(flags.password);
-      if (!email || !password) return finish(err("USAGE_ERROR", "login-console needs --email and --password"), flags);
+      const { email, password } = resolveConsoleLoginCredentials(flags);
+      if (!email || !password) {
+        return finish(
+          err(
+            "USAGE_ERROR",
+            "login-console needs --email/--password or DIFY_CONSOLE_EMAIL/DIFY_CONSOLE_PASSWORD",
+          ),
+          flags,
+        );
+      }
       const result = await consoleLogin(base, email, password);
       if (result.ok) storeCookies(base, result.data);
       return finish(result.ok ? { ok: true, data: { stored: true, base_url: base, cookies: Object.keys(result.data) } } : (result as Result<unknown>), flags);
@@ -303,6 +320,7 @@ function printHelp(positional: string[]): void {
     "  --base-url <url>              Dify base URL (or DIFY_API_BASE)",
     "  --workspace <id>              workspace id (or DIFY_WORKSPACE_ID)",
     "  --openapi-token / --console-token   tokens (or DIFY_OPENAPI_TOKEN / DIFY_CONSOLE_TOKEN)",
+    "  --email / --password            console login (or DIFY_CONSOLE_EMAIL / DIFY_CONSOLE_PASSWORD)",
     "  --yes                         confirm destructive ops (maps to confirm=true)",
     "  --dry-run                     validate + diff without saving",
     "  --graph <file|-|{json}>       graph input: file, stdin, or inline JSON",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ const CMD_ALIASES: Record<string, string> = {
   "workflow node run": "workflow.run_node",
 };
 const POSITIONALS: Record<string, string[]> = {
-  "app.get": ["app_id"], "app.update": ["app_id"], "app.list_tags": ["app_id"], "app.ensure_tag": ["app_id", "tag"], "app.delete": ["app_id"], "app.export": ["app_id"],
+  "app.get": ["app_id"], "app.update": ["app_id"], "app.list_tags": ["app_id"], "app.ensure_tag": ["app_id", "tag"], "app.remove_tag": ["app_id", "tag"], "app.delete": ["app_id"], "app.export": ["app_id"],
   "workflow.get_draft": ["app_id"], "workflow.node_defaults": ["app_id", "node_type"], "workflow.sync_draft": ["app_id"],
   "workflow.run_draft": ["app_id"], "workflow.run": ["app_id"], "workflow.publish": ["app_id"],
   "workflow.run_node": ["app_id", "node_id"], "workflow.events": ["app_id", "task_id"], "workflow.stop": ["app_id", "task_id"],

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -81,9 +81,13 @@ export async function consoleLogin(
   baseUrl: string,
   email: string,
   password: string,
+  passwordEncoding: "plain" | "base64" = "plain",
 ): Promise<Result<Record<string, string>>> {
+  const encodedPassword = passwordEncoding === "base64"
+    ? Buffer.from(password, "utf8").toString("base64")
+    : password;
   const r = await fetchCapturingCookies(baseUrl, "/console/api/login", {
-    body: { email, password, remember_me: true, language: "en-US" },
+    body: { email, password: encodedPassword, remember_me: true, language: "en-US" },
   });
   if (!r.ok) return r;
   const cookies = r.data.cookies;

--- a/src/graph/validate.ts
+++ b/src/graph/validate.ts
@@ -162,7 +162,12 @@ export function validateGraph(
   for (const n of nodes) {
     const t = nodeType(n);
     if (!t || !n.data) continue;
-    const required = requiredFields(t, opts?.defaults);
+    // Current Dify serializes multi-branch if/else nodes as `cases[]`, with
+    // conditions and logical_operator nested per case. Older single-branch
+    // exports keep those two fields at node.data. Accept either losslessly.
+    const modernIfCases =
+      t === "if-else" && Array.isArray(n.data.cases) && n.data.cases.length > 0;
+    const required = modernIfCases ? [] : requiredFields(t, opts?.defaults);
     for (const field of required) {
       if (n.data[field] === undefined) {
         issues.push({ level: "error", code: "MISSING_REQUIRED_FIELD", message: `node '${n.id}' (${t}) missing required field '${field}'`, nodeId: n.id });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -70,13 +70,16 @@ const transportMode = (
 ).toLowerCase();
 
 if (transportMode === "http") {
-  startHttpServer(Number(argValue("--port") ?? process.env.DIFYWF_MCP_PORT ?? 3000));
+  startHttpServer(
+    Number(argValue("--port") ?? process.env.DIFYWF_MCP_PORT ?? 3000),
+    argValue("--host") ?? process.env.DIFYWF_MCP_HOST ?? "0.0.0.0",
+  );
 } else {
   await createMcpServer().connect(new StdioServerTransport());
 }
 
 // --- Streamable HTTP transport (stateless, one server per request) ---
-function startHttpServer(port: number): void {
+function startHttpServer(port: number, host: string): void {
   const httpServer = createServer((req, res) => {
     handleHttpRequest(req, res).catch((e) => {
       if (!res.headersSent) {
@@ -85,8 +88,8 @@ function startHttpServer(port: number): void {
       }
     });
   });
-  httpServer.listen(port, () => {
-    process.stderr.write(`difywf MCP (Streamable HTTP) listening on http://0.0.0.0:${port}/mcp\n`);
+  httpServer.listen(port, host, () => {
+    process.stderr.write(`difywf MCP (Streamable HTTP) listening on http://${host}:${port}/mcp\n`);
   });
   const shutdown = (): void => { httpServer.close(); process.exit(0); };
   process.on("SIGINT", shutdown);

--- a/src/tools/guide.ts
+++ b/src/tools/guide.ts
@@ -49,7 +49,8 @@ Minimal required fields per type (validator enforces these):
 - llm: model{provider,name,mode}, prompt_template[]
 - code: code_language, code, outputs   http-request: method, url
 - knowledge-retrieval: query_variable_selector, dataset_ids
-- if-else: conditions, logical_operator   variable-aggregator: variables
+- if-else: non-empty cases[] OR legacy conditions + logical_operator
+  variable-aggregator: variables
 - tool: provider_id, provider_type, tool_name
 - parameter-extractor: query, model, parameters   assigner: items
 - iteration: iterator_selector, start_node_id   loop: start_node_id

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -168,6 +168,19 @@ export const tools: Tool[] = [
       (needClient(ctx, "console") as ConsoleClient).ensureAppTag(req(args, "app_id"), req(args, "tag")),
   },
   {
+    name: "app.remove_tag",
+    summary: "Unbind one exact-name tag from an app and verify readback. Requires confirm=true.",
+    needs: "console",
+    confirm: true,
+    schema: {
+      type: "object",
+      properties: { app_id: S("app uuid"), tag: S("exact app tag name"), confirm: CONFIRM },
+      required: ["app_id", "tag", "confirm"],
+    },
+    run: async (args, ctx) =>
+      (needClient(ctx, "console") as ConsoleClient).removeAppTag(req(args, "app_id"), req(args, "tag")),
+  },
+  {
     name: "app.delete",
     summary: "Delete an app. Destructive; requires confirm=true.",
     needs: "console",

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -482,26 +482,39 @@ export const tools: Tool[] = [
   },
   {
     name: "app.import",
-    summary: "Import an app from DSL. Handles the 2-step confirm flow. Installs plugins; requires confirm=true.",
-    needs: "openapi",
+    summary: "Import an app from DSL through console cookies or OpenAPI. Handles the 2-step confirm flow; requires confirm=true.",
     confirm: true,
-    schema: { type: "object", properties: { workspace_id: S("target workspace"), yaml: S("DSL YAML content"), yaml_url: S("...or YAML URL"), name: S("override name"), description: S(""), confirm: CONFIRM }, required: ["workspace_id", "confirm"] },
+    schema: { type: "object", properties: { workspace_id: S("target workspace; required only for OpenAPI fallback"), yaml: S("DSL YAML content"), yaml_url: S("...or YAML URL"), name: S("override name"), description: S(""), confirm: CONFIRM }, required: ["confirm"] },
     run: async (a, ctx) => {
-      const c = needClient(ctx, "openapi") as OpenapiClient;
-      const wid = req(a, "workspace_id");
       const body: Record<string, unknown> = {};
       if (str(a.yaml)) { body.mode = "yaml-content"; body.yaml_content = str(a.yaml); }
       else if (str(a.yaml_url)) { body.mode = "yaml-url"; body.yaml_url = str(a.yaml_url); }
       else throw new ToolError("USAGE_ERROR", "pass yaml (content) or yaml_url");
       if (str(a.name)) body.name = str(a.name);
       if (str(a.description)) body.description = str(a.description);
-      const imp = await c.importDsl(wid, body);
+      const consoleClient = ctx.console;
+      const openapiClient = ctx.openapi;
+      if (!consoleClient && !openapiClient) {
+        throw new ToolError("AUTH_REQUIRED", "app.import needs console cookies or an OpenAPI token");
+      }
+      const wid = str(a.workspace_id);
+      if (!consoleClient && !wid) {
+        throw new ToolError("USAGE_ERROR", "workspace_id is required for OpenAPI app.import");
+      }
+      const imp = consoleClient
+        ? await consoleClient.importDsl(body)
+        : await openapiClient!.importDsl(wid!, body);
       if (!imp.ok) return imp;
       const data = (imp.data ?? {}) as Record<string, unknown>;
       const importId = str(data.import_id) ?? str(data.id);
-      const pending = data.status === "pending" || data.result === "pending" || (importId && data.result === undefined);
+      const pending = data.status === "pending"
+        || data.status === "completed_but_needs_plugin_install"
+        || data.result === "pending"
+        || (importId && data.result === undefined && !str(data.app_id));
       if (importId && pending) {
-        const conf = await c.confirmImport(wid, importId);
+        const conf = consoleClient
+          ? await consoleClient.confirmImport(importId)
+          : await openapiClient!.confirmImport(wid!, importId);
         return conf.ok ? ok({ imported: true, confirmed: true, ...(conf.data as Record<string, unknown> ?? {}) }) : conf;
       }
       return ok({ imported: true, confirmed: false, ...data });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -278,6 +278,48 @@ export const tools: Tool[] = [
       (needClient(ctx, "console") as ConsoleClient).publish(req(args, "app_id"), pick(args, ["marked_name", "marked_comment"])),
   },
   {
+    name: "workflow.tool_get",
+    summary: "Get a workflow-as-tool provider by workflow app id or workflow tool id, including its synced status.",
+    needs: "console",
+    schema: {
+      type: "object",
+      properties: { app_id: S("workflow app uuid"), workflow_tool_id: S("workflow tool provider uuid") },
+      anyOf: [{ required: ["app_id"] }, { required: ["workflow_tool_id"] }],
+    },
+    run: async (args, ctx) => {
+      const appId = str(args.app_id);
+      const toolId = str(args.workflow_tool_id);
+      if (!appId && !toolId) throw new ToolError("USAGE_ERROR", "pass app_id or workflow_tool_id");
+      return (needClient(ctx, "console") as ConsoleClient).getWorkflowTool({ appId, toolId });
+    },
+  },
+  {
+    name: "workflow.tool_refresh_provider",
+    summary: "Create or update a workflow-as-tool provider so it targets the app's current published version; verifies synced=true.",
+    needs: "console",
+    confirm: true,
+    schema: {
+      type: "object",
+      properties: { app_id: S("published workflow app uuid"), confirm: CONFIRM },
+      required: ["app_id", "confirm"],
+    },
+    run: async (args, ctx) =>
+      (needClient(ctx, "console") as ConsoleClient).refreshWorkflowToolProvider(req(args, "app_id")),
+  },
+  {
+    name: "workflow.tool_delete",
+    summary: "Delete a workflow-as-tool provider. Destructive; requires confirm=true.",
+    needs: "console",
+    confirm: true,
+    schema: {
+      type: "object",
+      properties: { workflow_tool_id: S("workflow tool provider uuid"), confirm: CONFIRM },
+      required: ["workflow_tool_id", "confirm"],
+    },
+    run: async (args, ctx) =>
+      (needClient(ctx, "console") as ConsoleClient).deleteWorkflowTool(req(args, "workflow_tool_id")),
+  },
+  {
     name: "provider.list",
     summary: "List model providers configured in the workspace.",
     needs: "console",

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -147,6 +147,27 @@ export const tools: Tool[] = [
       (needClient(ctx, "console") as ConsoleClient).updateApp(req(args, "app_id"), pick(args, ["name", "description", "icon", "icon_type", "icon_background"])),
   },
   {
+    name: "app.list_tags",
+    summary: "List the exact tags currently bound to one app.",
+    needs: "console",
+    schema: { type: "object", properties: { app_id: S("app uuid") }, required: ["app_id"] },
+    run: async (args, ctx) =>
+      (needClient(ctx, "console") as ConsoleClient).getAppTags(req(args, "app_id")),
+  },
+  {
+    name: "app.ensure_tag",
+    summary: "Create an app tag if needed, bind it to an app, and verify exact-name readback. Requires confirm=true.",
+    needs: "console",
+    confirm: true,
+    schema: {
+      type: "object",
+      properties: { app_id: S("app uuid"), tag: S("exact app tag name"), confirm: CONFIRM },
+      required: ["app_id", "tag", "confirm"],
+    },
+    run: async (args, ctx) =>
+      (needClient(ctx, "console") as ConsoleClient).ensureAppTag(req(args, "app_id"), req(args, "tag")),
+  },
+  {
     name: "app.delete",
     summary: "Delete an app. Destructive; requires confirm=true.",
     needs: "console",

--- a/test/app-import-console.test.ts
+++ b/test/app-import-console.test.ts
@@ -1,0 +1,33 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ConsoleClient } from "../src/api/console.ts";
+
+test("ConsoleClient app import methods use the Dify Console API contract", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ url: string; method: string; body: unknown }> = [];
+  globalThis.fetch = async (input, init) => {
+    calls.push({
+      url: String(input),
+      method: String(init?.method ?? "GET"),
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    return new Response(JSON.stringify({ status: "completed", app_id: "app-1" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    const client = new ConsoleClient("https://dify.example", "token");
+    await client.importDsl({ mode: "yaml-content", yaml_content: "kind: app" });
+    await client.confirmImport("import-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.deepEqual(calls.map((call) => [call.method, new URL(call.url).pathname]), [
+    ["POST", "/console/api/apps/imports"],
+    ["POST", "/console/api/apps/imports/import-1/confirm"],
+  ]);
+  assert.deepEqual(calls[1].body, {});
+});

--- a/test/app-tags.test.ts
+++ b/test/app-tags.test.ts
@@ -24,6 +24,7 @@ test("ConsoleClient app-tag methods use the Dify Console API contract", async ()
     await client.listAppTags();
     await client.createAppTag("ndr-managed");
     await client.bindAppTag("app-1", "tag-1");
+    await client.removeAppTagBinding("app-1", "tag-1");
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -32,10 +33,12 @@ test("ConsoleClient app-tag methods use the Dify Console API contract", async ()
     ["GET", "/console/api/tags"],
     ["POST", "/console/api/tags"],
     ["POST", "/console/api/tag-bindings"],
+    ["POST", "/console/api/tag-bindings/remove"],
   ]);
   assert.equal(new URL(calls[0].url).searchParams.get("type"), "app");
   assert.deepEqual(calls[1].body, { name: "ndr-managed", type: "app" });
   assert.deepEqual(calls[2].body, { tag_ids: ["tag-1"], target_id: "app-1", type: "app" });
+  assert.deepEqual(calls[3].body, { tag_ids: ["tag-1"], target_id: "app-1", type: "app" });
 });
 
 test("ensureAppTag binds an existing exact-name tag and verifies readback", async () => {
@@ -87,6 +90,63 @@ test("app.ensure_tag is confirm-gated", async () => {
   const tool = tools.find((item) => item.name === "app.ensure_tag");
   assert.ok(tool);
   const result = await runTool(tool!, { app_id: "app-1", tag: "ndr-managed" }, { _surface: "mcp" });
+  assert.ok(!result.ok);
+  if (!result.ok) assert.equal(result.error.code, "CONFIRM_REQUIRED");
+});
+
+test("removeAppTag unbinds an exact-name tag and verifies readback", async () => {
+  const client = new ConsoleClient("https://dify.example", "token");
+  let reads = 0;
+  let removed: [string, string] | undefined;
+  client.getAppTags = async () => ok({
+    app_id: "app-1",
+    tags: reads++ === 0 ? [{ id: "tag-1", name: "workflow-beta-1.0" }] : [],
+  });
+  client.removeAppTagBinding = async (appId, tagId) => {
+    removed = [appId, tagId];
+    return ok({ result: "success" });
+  };
+
+  const result = await client.removeAppTag("app-1", "workflow-beta-1.0");
+
+  assert.ok(result.ok);
+  if (result.ok) assert.equal((result.data as Record<string, unknown>).action, "removed");
+  assert.deepEqual(removed, ["app-1", "tag-1"]);
+});
+
+test("removeAppTag performs zero writes when the exact tag is absent", async () => {
+  const client = new ConsoleClient("https://dify.example", "token");
+  client.getAppTags = async () => ok({ app_id: "app-1", tags: [] });
+  client.removeAppTagBinding = async () => { throw new Error("must not remove an absent tag"); };
+
+  const result = await client.removeAppTag("app-1", "workflow-beta-1.0");
+
+  assert.ok(result.ok);
+  if (result.ok) assert.equal((result.data as Record<string, unknown>).action, "unchanged");
+});
+
+test("removeAppTag fails closed when unbind readback still contains the tag", async () => {
+  const client = new ConsoleClient("https://dify.example", "token");
+  client.getAppTags = async () => ok({
+    app_id: "app-1",
+    tags: [{ id: "tag-1", name: "workflow-beta-1.0" }],
+  });
+  client.removeAppTagBinding = async () => ok({ result: "success" });
+
+  const result = await client.removeAppTag("app-1", "workflow-beta-1.0");
+
+  assert.ok(!result.ok);
+  if (!result.ok) assert.equal(result.error.code, "DSL_VERSION_MISMATCH");
+});
+
+test("app.remove_tag is confirm-gated", async () => {
+  const tool = tools.find((item) => item.name === "app.remove_tag");
+  assert.ok(tool);
+  const result = await runTool(
+    tool!,
+    { app_id: "app-1", tag: "workflow-beta-1.0" },
+    { _surface: "mcp" },
+  );
   assert.ok(!result.ok);
   if (!result.ok) assert.equal(result.error.code, "CONFIRM_REQUIRED");
 });

--- a/test/app-tags.test.ts
+++ b/test/app-tags.test.ts
@@ -1,0 +1,92 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ConsoleClient } from "../src/api/console.ts";
+import { ok } from "../src/core/contract.ts";
+import { runTool, tools } from "../src/tools/registry.ts";
+
+test("ConsoleClient app-tag methods use the Dify Console API contract", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ url: string; method: string; body: unknown }> = [];
+  globalThis.fetch = async (input, init) => {
+    calls.push({
+      url: String(input),
+      method: String(init?.method ?? "GET"),
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    return new Response(JSON.stringify([]), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    const client = new ConsoleClient("https://dify.example", "token");
+    await client.listAppTags();
+    await client.createAppTag("ndr-managed");
+    await client.bindAppTag("app-1", "tag-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.deepEqual(calls.map((call) => [call.method, new URL(call.url).pathname]), [
+    ["GET", "/console/api/tags"],
+    ["POST", "/console/api/tags"],
+    ["POST", "/console/api/tag-bindings"],
+  ]);
+  assert.equal(new URL(calls[0].url).searchParams.get("type"), "app");
+  assert.deepEqual(calls[1].body, { name: "ndr-managed", type: "app" });
+  assert.deepEqual(calls[2].body, { tag_ids: ["tag-1"], target_id: "app-1", type: "app" });
+});
+
+test("ensureAppTag binds an existing exact-name tag and verifies readback", async () => {
+  const client = new ConsoleClient("https://dify.example", "token");
+  let reads = 0;
+  let bound: [string, string] | undefined;
+  client.getAppTags = async () => ok({
+    app_id: "app-1",
+    tags: reads++ === 0 ? [] : [{ id: "tag-1", name: "ndr-managed" }],
+  });
+  client.listAppTags = async () => ok([{ id: "tag-1", name: "ndr-managed" }]);
+  client.createAppTag = async () => { throw new Error("must not create an existing tag"); };
+  client.bindAppTag = async (appId, tagId) => {
+    bound = [appId, tagId];
+    return ok({ result: "success" });
+  };
+
+  const result = await client.ensureAppTag("app-1", "ndr-managed");
+
+  assert.ok(result.ok);
+  if (result.ok) assert.equal((result.data as Record<string, unknown>).action, "bound");
+  assert.deepEqual(bound, ["app-1", "tag-1"]);
+});
+
+test("ensureAppTag performs zero writes when exact tag is already bound", async () => {
+  const client = new ConsoleClient("https://dify.example", "token");
+  client.getAppTags = async () => ok({ app_id: "app-1", tags: [{ id: "tag-1", name: "ndr-managed" }] });
+  client.listAppTags = async () => { throw new Error("must not list workspace tags"); };
+
+  const result = await client.ensureAppTag("app-1", "ndr-managed");
+
+  assert.ok(result.ok);
+  if (result.ok) assert.equal((result.data as Record<string, unknown>).action, "unchanged");
+});
+
+test("ensureAppTag fails closed when bind readback is missing", async () => {
+  const client = new ConsoleClient("https://dify.example", "token");
+  client.getAppTags = async () => ok({ app_id: "app-1", tags: [] });
+  client.listAppTags = async () => ok([{ id: "tag-1", name: "ndr-managed" }]);
+  client.bindAppTag = async () => ok({ result: "success" });
+
+  const result = await client.ensureAppTag("app-1", "ndr-managed");
+
+  assert.ok(!result.ok);
+  if (!result.ok) assert.equal(result.error.code, "DSL_VERSION_MISMATCH");
+});
+
+test("app.ensure_tag is confirm-gated", async () => {
+  const tool = tools.find((item) => item.name === "app.ensure_tag");
+  assert.ok(tool);
+  const result = await runTool(tool!, { app_id: "app-1", tag: "ndr-managed" }, { _surface: "mcp" });
+  assert.ok(!result.ok);
+  if (!result.ok) assert.equal(result.error.code, "CONFIRM_REQUIRED");
+});

--- a/test/auth-cookie.test.ts
+++ b/test/auth-cookie.test.ts
@@ -144,6 +144,21 @@ test("consoleLogin captures cookies from Set-Cookie", async () => {
   );
 });
 
+test("consoleLogin optionally base64-encodes the password payload", async () => {
+  let body = "";
+  await withFetch(
+    async (_url, init) => {
+      body = String((init as { body?: string }).body ?? "");
+      return mockResponse(200, { result: "success" }, ["console_token=abc; Path=/"]);
+    },
+    async () => {
+      const r = await consoleLogin("http://x", "a@b.com", "secret", "base64");
+      assert.ok(r.ok);
+    },
+  );
+  assert.equal(JSON.parse(body).password, Buffer.from("secret", "utf8").toString("base64"));
+});
+
 test("refreshConsoleCookies merges new cookies onto existing (keeps refresh_token)", async () => {
   await withFetch(
     async () => mockResponse(200, { result: "success" }, ["console_token=newt; Path=/"]),

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,10 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync } from "node:fs";
+import fs, { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { parseFlags, resolveConsoleLoginCredentials } from "../src/cli.ts";
+import { parseFlags, readTextArg, resolveConsoleLoginCredentials } from "../src/cli.ts";
 
 test("parseFlags handles positionals, values, =values, booleans, repeats", () => {
   const { positional, flags } = parseFlags([
@@ -61,4 +61,14 @@ test("output-file carries large structured results outside stdout", () => {
   assert.equal(acknowledgement.output_file, output);
   assert.equal(result.ok, true);
   assert.match(result.data, /golden path/i);
+});
+
+test("yaml @file carries DSLs larger than the operating-system argument limit", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "difywf-yaml-"));
+  const source = path.join(dir, "workflow.yml");
+  const yaml = `kind: app\nworkflow:\n  graph:\n    note: ${"x".repeat(200_000)}\n`;
+  fs.writeFileSync(source, yaml, "utf8");
+  assert.equal(readTextArg(`@${source}`, "yaml"), yaml);
+  assert.equal(readTextArg("kind: app\n", "yaml"), "kind: app\n");
+  assert.throws(() => readTextArg(`@${source}.missing`, "yaml"), /file not found/);
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -20,13 +20,23 @@ test("console login credentials prefer flags and fall back to environment", () =
       DIFY_CONSOLE_EMAIL: "bot@example.com",
       DIFY_CONSOLE_PASSWORD: "from-env",
     }),
-    { email: "bot@example.com", password: "from-env" },
+    { email: "bot@example.com", password: "from-env", passwordEncoding: "plain" },
   );
   assert.deepEqual(
     resolveConsoleLoginCredentials(
       { email: "flag@example.com", password: "from-flags" },
       { DIFY_CONSOLE_EMAIL: "env@example.com", DIFY_CONSOLE_PASSWORD: "from-env" },
     ),
-    { email: "flag@example.com", password: "from-flags" },
+    { email: "flag@example.com", password: "from-flags", passwordEncoding: "plain" },
+  );
+  assert.equal(
+    resolveConsoleLoginCredentials({}, {
+      DIFY_CONSOLE_PASSWORD_ENCODING: "base64",
+    }).passwordEncoding,
+    "base64",
+  );
+  assert.throws(
+    () => resolveConsoleLoginCredentials({}, { DIFY_CONSOLE_PASSWORD_ENCODING: "rot13" }),
+    /plain.*base64/,
   );
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { parseFlags, resolveConsoleLoginCredentials } from "../src/cli.ts";
 
 test("parseFlags handles positionals, values, =values, booleans, repeats", () => {
@@ -7,11 +11,13 @@ test("parseFlags handles positionals, values, =values, booleans, repeats", () =>
     "wf", "run", "app-1",
     "--input", "a=1", "--input", "b=2",
     "--yes", "--graph=test/fixtures/valid.json", "-o", "json",
+    "--output-file", "/tmp/difywf-result.json",
   ]);
   assert.deepEqual(positional, ["wf", "run", "app-1"]);
   assert.deepEqual(flags.input, ["a=1", "b=2"]);
   assert.equal(flags.yes, true);
   assert.equal(flags.graph, "test/fixtures/valid.json");
+  assert.equal(flags["output-file"], "/tmp/difywf-result.json");
 });
 
 test("console login credentials prefer flags and fall back to environment", () => {
@@ -39,4 +45,20 @@ test("console login credentials prefer flags and fall back to environment", () =
     () => resolveConsoleLoginCredentials({}, { DIFY_CONSOLE_PASSWORD_ENCODING: "rot13" }),
     /plain.*base64/,
   );
+});
+
+test("output-file carries large structured results outside stdout", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "difywf-output-"));
+  const output = path.join(dir, "result.json");
+  const stdout = execFileSync(
+    process.execPath,
+    ["bin/difywf.js", "agent", "guide", "all", "--output", "json", "--output-file", output],
+    { encoding: "utf8" },
+  );
+  const acknowledgement = JSON.parse(stdout);
+  const result = JSON.parse(readFileSync(output, "utf8"));
+  assert.equal(acknowledgement.ok, true);
+  assert.equal(acknowledgement.output_file, output);
+  assert.equal(result.ok, true);
+  assert.match(result.data, /golden path/i);
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseFlags } from "../src/cli.ts";
+import { parseFlags, resolveConsoleLoginCredentials } from "../src/cli.ts";
 
 test("parseFlags handles positionals, values, =values, booleans, repeats", () => {
   const { positional, flags } = parseFlags([
@@ -12,4 +12,21 @@ test("parseFlags handles positionals, values, =values, booleans, repeats", () =>
   assert.deepEqual(flags.input, ["a=1", "b=2"]);
   assert.equal(flags.yes, true);
   assert.equal(flags.graph, "test/fixtures/valid.json");
+});
+
+test("console login credentials prefer flags and fall back to environment", () => {
+  assert.deepEqual(
+    resolveConsoleLoginCredentials({}, {
+      DIFY_CONSOLE_EMAIL: "bot@example.com",
+      DIFY_CONSOLE_PASSWORD: "from-env",
+    }),
+    { email: "bot@example.com", password: "from-env" },
+  );
+  assert.deepEqual(
+    resolveConsoleLoginCredentials(
+      { email: "flag@example.com", password: "from-flags" },
+      { DIFY_CONSOLE_EMAIL: "env@example.com", DIFY_CONSOLE_PASSWORD: "from-env" },
+    ),
+    { email: "flag@example.com", password: "from-flags" },
+  );
 });

--- a/test/deferred.test.ts
+++ b/test/deferred.test.ts
@@ -11,10 +11,10 @@ const fakeCtx = (overrides: Partial<ToolCtx> = {}): ToolCtx => ({
   ...overrides,
 });
 
-test("registry has 143 tools, all names unique", () => {
+test("registry has 144 tools, all names unique", () => {
   const names = tools.map((t) => t.name);
-  assert.equal(names.length, 143);
-  assert.equal(new Set(names).size, 143);
+  assert.equal(names.length, 144);
+  assert.equal(new Set(names).size, 144);
 });
 
 test("every tool name is ns.verb and maps to an MCP-safe name", () => {

--- a/test/deferred.test.ts
+++ b/test/deferred.test.ts
@@ -11,10 +11,10 @@ const fakeCtx = (overrides: Partial<ToolCtx> = {}): ToolCtx => ({
   ...overrides,
 });
 
-test("registry has 138 tools, all names unique", () => {
+test("registry has 141 tools, all names unique", () => {
   const names = tools.map((t) => t.name);
-  assert.equal(names.length, 138);
-  assert.equal(new Set(names).size, 138);
+  assert.equal(names.length, 141);
+  assert.equal(new Set(names).size, 141);
 });
 
 test("every tool name is ns.verb and maps to an MCP-safe name", () => {

--- a/test/deferred.test.ts
+++ b/test/deferred.test.ts
@@ -11,10 +11,10 @@ const fakeCtx = (overrides: Partial<ToolCtx> = {}): ToolCtx => ({
   ...overrides,
 });
 
-test("registry has 141 tools, all names unique", () => {
+test("registry has 143 tools, all names unique", () => {
   const names = tools.map((t) => t.name);
-  assert.equal(names.length, 141);
-  assert.equal(new Set(names).size, 141);
+  assert.equal(names.length, 143);
+  assert.equal(new Set(names).size, 143);
 });
 
 test("every tool name is ns.verb and maps to an MCP-safe name", () => {

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -39,6 +39,27 @@ test("app.import skips confirm when import completes immediately", async () => {
   if (r.ok) assert.equal((r.data as Record<string, unknown>).confirmed, false);
 });
 
+test("app.import prefers console cookies and does not require workspace_id", async () => {
+  const calls: string[] = [];
+  const fake = {
+    importDsl: async (_body: Record<string, unknown>): Promise<Result<unknown>> => {
+      calls.push("import");
+      return { ok: true, data: { id: "i1", status: "completed_but_needs_plugin_install" } };
+    },
+    confirmImport: async (id: string): Promise<Result<unknown>> => {
+      calls.push(`confirm:${id}`);
+      return { ok: true, data: { status: "completed", app_id: "new-app" } };
+    },
+  };
+  const r = await find("app.import").run(
+    { yaml: "kind: app", confirm: true },
+    fakeCtx({ openapi: null, console: fake as never }),
+  );
+  assert.ok(r.ok);
+  if (r.ok) assert.equal((r.data as Record<string, unknown>).confirmed, true);
+  assert.deepEqual(calls, ["import", "confirm:i1"]);
+});
+
 test("workflow.sync_draft dry_run returns a structural diff", async () => {
   const current = {
     graph: {

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -58,6 +58,41 @@ test("missing required field per node type", () => {
   assert.ok(got.includes("MISSING_REQUIRED_FIELD"));
 });
 
+test("modern multi-case if-else does not require legacy node-level conditions", () => {
+  const graph: Graph = {
+    nodes: [
+      { id: "s", data: { type: "start", variables: [{ variable: "route" }] } },
+      {
+        id: "if1",
+        data: {
+          type: "if-else",
+          cases: [
+            {
+              id: "case-a",
+              case_id: "case-a",
+              logical_operator: "and",
+              conditions: [
+                {
+                  id: "condition-a",
+                  variable_selector: ["s", "route"],
+                  comparison_operator: "is",
+                  value: "a",
+                },
+              ],
+            },
+          ],
+        },
+      },
+      { id: "e", data: { type: "end", outputs: [] } },
+    ],
+    edges: [
+      { source: "s", target: "if1" },
+      { source: "if1", sourceHandle: "case-a", target: "e" },
+    ],
+  };
+  assert.deepEqual(codes(validateGraph(graph)), []);
+});
+
 test("sys and env references are not treated as node refs", () => {
   const graph: Graph = {
     nodes: [
@@ -97,4 +132,3 @@ test("all example templates in examples/ produce no error-level issues", () => {
     assert.deepEqual(codes(issues), [], `Expected no error issues in ${file}, got: ${JSON.stringify(issues)}`);
   }
 });
-

--- a/test/workflow-tool.test.ts
+++ b/test/workflow-tool.test.ts
@@ -1,0 +1,172 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ConsoleClient } from "../src/api/console.ts";
+import { err, ok } from "../src/core/contract.ts";
+import { runTool, tools } from "../src/tools/registry.ts";
+
+const startDraft = (...names: string[]): Record<string, unknown> => ({
+  graph: {
+    nodes: [{
+      id: "start",
+      data: { type: "start", variables: names.map((variable) => ({ variable, type: "text-input" })) },
+    }],
+    edges: [],
+  },
+});
+
+test("ConsoleClient workflow-tool methods use the Dify Console API contract", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ url: string; method: string; body: unknown }> = [];
+  globalThis.fetch = async (input, init) => {
+    calls.push({
+      url: String(input),
+      method: String(init?.method ?? "GET"),
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    return new Response(JSON.stringify({ result: "success", synced: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    const client = new ConsoleClient("https://dify.example", "token");
+    await client.getWorkflowTool({ appId: "app-1" });
+    await client.createWorkflowTool({ workflow_app_id: "app-1" });
+    await client.updateWorkflowTool({ workflow_tool_id: "tool-1" });
+    await client.deleteWorkflowTool("tool-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(calls[0].url, "https://dify.example/console/api/workspaces/current/tool-provider/workflow/get?workflow_app_id=app-1");
+  assert.equal(calls[0].method, "GET");
+  assert.deepEqual(calls.slice(1).map((call) => [call.method, new URL(call.url).pathname]), [
+    ["POST", "/console/api/workspaces/current/tool-provider/workflow/create"],
+    ["POST", "/console/api/workspaces/current/tool-provider/workflow/update"],
+    ["POST", "/console/api/workspaces/current/tool-provider/workflow/delete"],
+  ]);
+  assert.deepEqual(calls[3].body, { workflow_tool_id: "tool-1" });
+});
+
+test("workflow-tool lookup normalizes Dify's Tool not found variants", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({ message: "Tool not found" }), {
+    status: 400,
+    headers: { "content-type": "application/json" },
+  });
+  try {
+    const result = await new ConsoleClient("https://dify.example", "token").getWorkflowTool({ appId: "app-1" });
+    assert.ok(!result.ok);
+    if (!result.ok) assert.equal(result.error.code, "NOT_FOUND");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("refresh creates a missing provider and verifies readback", async () => {
+  const client = new ConsoleClient("https://dify.example", "token");
+  let reads = 0;
+  let created: Record<string, unknown> | undefined;
+  client.getWorkflowTool = async () => reads++ === 0
+    ? err("NOT_FOUND", "Tool not found")
+    : ok({ workflow_tool_id: "tool-1", workflow_app_id: "app-1", synced: true });
+  client.getApp = async () => ok({ name: "123 child", description: "child workflow", icon: "\ud83e\udde9", icon_background: "#fff" });
+  client.getDraft = async () => ok(startDraft("query"));
+  client.createWorkflowTool = async (body) => {
+    created = body;
+    return ok({ result: "success" });
+  };
+
+  const result = await client.refreshWorkflowToolProvider("app-1");
+
+  assert.ok(result.ok);
+  if (result.ok) assert.equal((result.data as Record<string, unknown>).action, "created");
+  assert.deepEqual(created, {
+    workflow_app_id: "app-1",
+    name: "tool_123_child",
+    label: "123 child",
+    description: "child workflow",
+    icon: { content: "\ud83e\udde9", background: "#fff" },
+    parameters: [{ name: "query", description: "", form: "form" }],
+    labels: [],
+    privacy_policy: "",
+  });
+});
+
+test("refresh updates a stale provider while preserving its authored metadata", async () => {
+  const client = new ConsoleClient("https://dify.example", "token");
+  const before = {
+    workflow_tool_id: "tool-1",
+    workflow_app_id: "app-1",
+    synced: false,
+    name: "stable_name",
+    label: "Stable label",
+    description: "kept",
+    icon: { content: "x", background: "#000" },
+    parameters: [{ name: "query", description: "kept input", form: "llm" }],
+    tool: { labels: ["managed"] },
+    privacy_policy: "policy",
+  };
+  let reads = 0;
+  let updated: Record<string, unknown> | undefined;
+  client.getWorkflowTool = async () => reads++ === 0 ? ok(before) : ok({ ...before, synced: true });
+  client.getApp = async () => ok({ name: "renamed app" });
+  client.getDraft = async () => ok(startDraft("query", "new_input"));
+  client.updateWorkflowTool = async (body) => {
+    updated = body;
+    return ok({ result: "success" });
+  };
+
+  const result = await client.refreshWorkflowToolProvider("app-1");
+
+  assert.ok(result.ok);
+  if (result.ok) assert.equal((result.data as Record<string, unknown>).action, "updated");
+  assert.deepEqual(updated, {
+    workflow_tool_id: "tool-1",
+    name: "stable_name",
+    label: "Stable label",
+    description: "kept",
+    icon: { content: "x", background: "#000" },
+    parameters: [
+      { name: "query", description: "kept input", form: "llm" },
+      { name: "new_input", description: "", form: "form" },
+    ],
+    labels: ["managed"],
+    privacy_policy: "policy",
+  });
+});
+
+test("refresh performs zero writes when the provider is already synced", async () => {
+  const client = new ConsoleClient("https://dify.example", "token");
+  client.getWorkflowTool = async () => ok({ workflow_tool_id: "tool-1", synced: true });
+  client.getApp = async () => { throw new Error("must not read app"); };
+  client.getDraft = async () => { throw new Error("must not read draft"); };
+
+  const result = await client.refreshWorkflowToolProvider("app-1");
+
+  assert.ok(result.ok);
+  if (result.ok) assert.equal((result.data as Record<string, unknown>).action, "unchanged");
+});
+
+test("refresh fails closed when readback remains stale", async () => {
+  const client = new ConsoleClient("https://dify.example", "token");
+  const stale = { workflow_tool_id: "tool-1", workflow_app_id: "app-1", synced: false };
+  client.getWorkflowTool = async () => ok(stale);
+  client.getApp = async () => ok({ name: "child" });
+  client.getDraft = async () => ok(startDraft("query"));
+  client.updateWorkflowTool = async () => ok({ result: "success" });
+
+  const result = await client.refreshWorkflowToolProvider("app-1");
+
+  assert.ok(!result.ok);
+  if (!result.ok) assert.equal(result.error.code, "DSL_VERSION_MISMATCH");
+});
+
+test("workflow.tool_refresh_provider is confirm-gated", async () => {
+  const tool = tools.find((item) => item.name === "workflow.tool_refresh_provider");
+  assert.ok(tool);
+  const result = await runTool(tool!, { app_id: "app-1" }, { _surface: "mcp" });
+  assert.ok(!result.ok);
+  if (!result.ok) assert.equal(result.error.code, "CONFIRM_REQUIRED");
+});


### PR DESCRIPTION
## Summary

- add workflow-as-tool provider get, refresh, and delete operations to the shared CLI/MCP registry
- make refresh idempotent: create a missing provider, update a stale provider, and perform zero writes when `synced=true`
- preserve authored provider metadata, rebuild Start-node parameter configuration, normalize Dify's inconsistent `Tool not found` responses, and fail closed unless readback reports `synced=true`
- expose the MCP capability as `workflow_tool_refresh_provider` and require explicit confirmation for refresh/delete
- add `app_list_tags` plus confirm-gated `app_ensure_tag`, with exact-name matching, create-if-missing, binding, and readback verification
- let `app_import` use an existing Console cookie/CSRF session, with OpenAPI plus `workspace_id` retained as the fallback
- allow non-interactive `login-console` bootstrap from `DIFY_CONSOLE_EMAIL` and `DIFY_CONSOLE_PASSWORD`, keeping credentials out of process arguments while preserving flag precedence
- allow the Streamable HTTP server bind address to be set with `--host` or `DIFYWF_MCP_HOST`, so host-network deployments can remain loopback-only
- support explicit `plain`/`base64` console-password payload encoding for Dify deployments whose login decryptor rejects plaintext
- add `--output-file` so large UTF-8 draft/export results avoid size-limited stdout transports while retaining the full structured result contract

## Why

Dify stores a workflow tool provider's bound workflow version separately from the app's current published version. Publishing a new workflow version can therefore leave callers on the previous version until the provider is updated. The Console API exposes this as `synced=false`.

Safe automated mutation also needs a server-readback ownership boundary. The app-tag tools let callers bind a managed tag to disposable apps and prove that exact tag is present before publishing or deleting them, without adding downstream Dify HTTP code.

Containerized callers need to initialize the existing cookie/CSRF session from an external secret store. Environment-backed console login lets them use the same community auth implementation without exposing the password in command arguments.

Large workflow graphs can exceed stdout limits imposed by container or agent transports. A caller-provided output file lets the CLI preserve the complete JSON result and Unicode boundaries without changing the MCP tool surface.

## Validation

- Node 24.7 `npm test`: 71 passed
- `npm run typecheck`
- `npm run smoke:mcp`: 143 tools
- `npm run smoke:mcp:http`
- downstream offline contract probe: no missing core/cutover tools and confirm gates passed
- downstream large-result probe: 100-row app page and a previously truncated large draft both parsed through the file channel

The new HTTP paths and orchestration are unit tested. A downstream recoverable
live contract also passed against its already-configured Dify instance using
only randomly named disposable applications carrying an exact managed tag. It
covered app create/import/get/export/delete; draft hash sync and stale-hash
zero-write; stable node/edge CRUD and unknown-field round-trip; node/draft run;
publish/version readback; workflow-tool refresh/get/delete; and final
NOT_FOUND cleanup readback. No existing business app was modified, and the
contract left no disposable application or workflow-tool provider behind.
